### PR TITLE
Add Firestore field stale behavior settings and activity logging

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -9,6 +9,7 @@ electronLanguages:
 files:
   - .build/out/**
   - package.json
+  - "!node_modules/@firebase-desk/**"
 mac:
   icon: build/icon.icns
   identity: null

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -4,6 +4,8 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import monacoEditorPlugin from 'vite-plugin-monaco-editor';
 
+import { mainExternalizeDeps } from './src/main/packaging/main-externalize-deps';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const monacoEditorPluginFactory =
   (monacoEditorPlugin as unknown as { default?: typeof monacoEditorPlugin; }).default
@@ -12,6 +14,7 @@ const monacoEditorPluginFactory =
 export default defineConfig({
   main: {
     build: {
+      externalizeDeps: mainExternalizeDeps,
       outDir: '.build/out/main',
       lib: {
         entry: {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -30,6 +30,7 @@
     "@firebase-desk/ui": "workspace:*",
     "@tanstack/react-query": "5.90.12",
     "@tanstack/react-store": "0.11.0",
+    "firebase-admin": "13.8.0",
     "lucide-react": "1.11.0",
     "react": "19.2.5",
     "react-dom": "19.2.5",

--- a/apps/desktop/src/main/activity/main-activity-log-repository.test.ts
+++ b/apps/desktop/src/main/activity/main-activity-log-repository.test.ts
@@ -1,0 +1,163 @@
+import {
+  type ActivityLogSettings,
+  DEFAULT_ACTIVITY_LOG_SETTINGS,
+  type HotkeyOverrides,
+  type SettingsPatch,
+  type SettingsRepository,
+  type SettingsSnapshot,
+} from '@firebase-desk/repo-contracts';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ActivityLogStore } from '../storage/activity-log-store.ts';
+import { DEFAULT_SETTINGS_SNAPSHOT } from '../storage/settings-store.ts';
+import { MainActivityLogRepository } from './main-activity-log-repository.ts';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
+});
+
+describe('MainActivityLogRepository', () => {
+  it('stores metadata only by default and strips credential fields', async () => {
+    const repository = await makeRepository({
+      detailMode: 'metadata',
+      enabled: true,
+      maxBytes: 1024 * 1024,
+    });
+
+    const entry = await repository.append({
+      action: 'Add account',
+      area: 'projects',
+      metadata: { serviceAccountJson: '{}', name: 'Local' },
+      payload: { data: { ok: true } },
+      status: 'success',
+      summary: 'Added Local',
+    });
+
+    expect(entry.payload).toBeUndefined();
+    expect(entry.metadata).toEqual({ name: 'Local' });
+    await expect(repository.list()).resolves.toHaveLength(1);
+  });
+
+  it('stores allowed full payloads and strips credential fields', async () => {
+    const repository = await makeRepository({
+      detailMode: 'fullPayload',
+      enabled: true,
+      maxBytes: 1024 * 1024,
+    });
+
+    const entry = await repository.append({
+      action: 'Save document',
+      area: 'firestore',
+      payload: { data: { privateKey: 'secret', title: 'Saved' } },
+      status: 'success',
+      summary: 'Saved orders/ord_1',
+    });
+
+    expect(entry.payload).toEqual({ data: { title: 'Saved' } });
+  });
+
+  it('marks oversized payloads as truncated', async () => {
+    const repository = await makeRepository({
+      detailMode: 'fullPayload',
+      enabled: true,
+      maxBytes: 400,
+    });
+
+    const entry = await repository.append({
+      action: 'Save document',
+      area: 'firestore',
+      metadata: { path: 'orders/ord_1' },
+      payload: { data: { body: 'x'.repeat(1000) } },
+      status: 'success',
+      summary: 'Saved orders/ord_1',
+    });
+
+    expect(entry.payload).toBeUndefined();
+    expect(entry.metadata).toMatchObject({ path: 'orders/ord_1', payloadTruncated: true });
+  });
+
+  it('exports filtered JSONL through the save dialog path', async () => {
+    const dir = await makeTempDir();
+    const settings = new MemorySettingsRepository(DEFAULT_ACTIVITY_LOG_SETTINGS);
+    const exportPath = join(dir, 'activity-export.jsonl');
+    const repository = new MainActivityLogRepository(new ActivityLogStore(dir), settings, {
+      showSaveDialog: vi.fn(async () => ({ canceled: false, filePath: exportPath })),
+    });
+    await repository.append({
+      action: 'Save document',
+      area: 'firestore',
+      status: 'success',
+      summary: 'Saved',
+    });
+    await repository.append({
+      action: 'Search users',
+      area: 'auth',
+      status: 'failure',
+      summary: 'Failed',
+    });
+
+    await expect(repository.export({ area: 'auth' })).resolves.toEqual({
+      canceled: false,
+      filePath: exportPath,
+    });
+
+    const exported = await readFile(exportPath, 'utf8');
+    expect(exported).toContain('"area":"auth"');
+    expect(exported).not.toContain('"area":"firestore"');
+  });
+});
+
+async function makeRepository(settings: ActivityLogSettings): Promise<MainActivityLogRepository> {
+  return new MainActivityLogRepository(
+    new ActivityLogStore(await makeTempDir()),
+    new MemorySettingsRepository(settings),
+    { showSaveDialog: vi.fn(async () => ({ canceled: true })) },
+  );
+}
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'firebase-desk-activity-repo-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+class MemorySettingsRepository implements SettingsRepository {
+  private snapshot: SettingsSnapshot;
+
+  constructor(activityLog: ActivityLogSettings) {
+    this.snapshot = { ...DEFAULT_SETTINGS_SNAPSHOT, activityLog };
+  }
+
+  async load(): Promise<SettingsSnapshot> {
+    return this.snapshot;
+  }
+
+  async save(patch: SettingsPatch): Promise<SettingsSnapshot> {
+    this.snapshot = {
+      ...this.snapshot,
+      ...(patch.activityLog ? { activityLog: patch.activityLog } : {}),
+      ...(patch.dataMode ? { dataMode: patch.dataMode } : {}),
+      ...(patch.firestoreFieldCatalogs
+        ? { firestoreFieldCatalogs: patch.firestoreFieldCatalogs }
+        : {}),
+      ...(patch.hotkeyOverrides ? { hotkeyOverrides: patch.hotkeyOverrides } : {}),
+      ...(patch.inspectorWidth === undefined ? {} : { inspectorWidth: patch.inspectorWidth }),
+      ...(patch.resultTableLayouts ? { resultTableLayouts: patch.resultTableLayouts } : {}),
+      ...(patch.sidebarWidth === undefined ? {} : { sidebarWidth: patch.sidebarWidth }),
+      ...(patch.theme ? { theme: patch.theme } : {}),
+    };
+    return this.snapshot;
+  }
+
+  async getHotkeyOverrides(): Promise<HotkeyOverrides> {
+    return this.snapshot.hotkeyOverrides;
+  }
+
+  async setHotkeyOverrides(overrides: HotkeyOverrides): Promise<void> {
+    this.snapshot = { ...this.snapshot, hotkeyOverrides: overrides };
+  }
+}

--- a/apps/desktop/src/main/activity/main-activity-log-repository.test.ts
+++ b/apps/desktop/src/main/activity/main-activity-log-repository.test.ts
@@ -144,6 +144,7 @@ class MemorySettingsRepository implements SettingsRepository {
       ...(patch.firestoreFieldCatalogs
         ? { firestoreFieldCatalogs: patch.firestoreFieldCatalogs }
         : {}),
+      ...(patch.firestoreWrites ? { firestoreWrites: patch.firestoreWrites } : {}),
       ...(patch.hotkeyOverrides ? { hotkeyOverrides: patch.hotkeyOverrides } : {}),
       ...(patch.inspectorWidth === undefined ? {} : { inspectorWidth: patch.inspectorWidth }),
       ...(patch.resultTableLayouts ? { resultTableLayouts: patch.resultTableLayouts } : {}),

--- a/apps/desktop/src/main/activity/main-activity-log-repository.ts
+++ b/apps/desktop/src/main/activity/main-activity-log-repository.ts
@@ -1,0 +1,154 @@
+import type {
+  ActivityLogAppendInput,
+  ActivityLogEntry,
+  ActivityLogError,
+  ActivityLogExportResult,
+  ActivityLogListRequest,
+  ActivityLogRepository,
+  ActivityLogSettings,
+  SettingsRepository,
+} from '@firebase-desk/repo-contracts';
+import { randomUUID } from 'node:crypto';
+import type { ActivityLogStore } from '../storage/activity-log-store.ts';
+
+export interface ActivityLogSaveDialog {
+  showSaveDialog(): Promise<{ readonly canceled: boolean; readonly filePath?: string; }>;
+}
+
+export class MainActivityLogRepository implements ActivityLogRepository {
+  constructor(
+    private readonly store: ActivityLogStore,
+    private readonly settings: SettingsRepository,
+    private readonly saveDialog: ActivityLogSaveDialog,
+  ) {}
+
+  async append(input: ActivityLogAppendInput): Promise<ActivityLogEntry> {
+    const settings = (await this.settings.load()).activityLog;
+    const entry = sanitizeEntry({
+      ...input,
+      id: randomUUID(),
+      timestamp: new Date().toISOString(),
+    }, settings);
+    if (settings.enabled) await this.store.append(entry, settings.maxBytes);
+    return entry;
+  }
+
+  async clear(): Promise<void> {
+    await this.store.clear();
+  }
+
+  async export(request?: ActivityLogListRequest): Promise<ActivityLogExportResult> {
+    const result = await this.saveDialog.showSaveDialog();
+    if (result.canceled || !result.filePath) return { canceled: true };
+    const entries = filterEntries(await this.store.list(), request);
+    await this.store.exportTo(result.filePath, reverseEntries(entries));
+    return { canceled: false, filePath: result.filePath };
+  }
+
+  async list(request?: ActivityLogListRequest): Promise<ReadonlyArray<ActivityLogEntry>> {
+    return filterEntries(await this.store.list(), request);
+  }
+
+  async prune(): Promise<void> {
+    await this.store.prune((await this.settings.load()).activityLog.maxBytes);
+  }
+}
+
+function sanitizeEntry(entry: ActivityLogEntry, settings: ActivityLogSettings): ActivityLogEntry {
+  const safePayload = settings.detailMode === 'fullPayload'
+    ? sanitizeRecord(entry.payload)
+    : undefined;
+  const candidate: ActivityLogEntry = {
+    action: entry.action,
+    area: entry.area,
+    ...(entry.durationMs === undefined ? {} : { durationMs: entry.durationMs }),
+    ...(entry.error === undefined ? {} : { error: entry.error }),
+    id: entry.id,
+    metadata: sanitizeRecord(entry.metadata),
+    ...(safePayload ? { payload: safePayload } : {}),
+    status: entry.status,
+    summary: entry.summary,
+    ...(entry.target === undefined ? {} : { target: entry.target }),
+    timestamp: entry.timestamp,
+  };
+  if (byteLength(JSON.stringify(candidate)) <= settings.maxBytes) return candidate;
+  return {
+    ...candidate,
+    metadata: {
+      ...candidate.metadata,
+      payloadTruncated: true,
+    },
+    payload: undefined,
+  };
+}
+
+function sanitizeRecord(
+  record: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!record) return undefined;
+  const sanitized = sanitizeValue(record);
+  return sanitized && typeof sanitized === 'object' && !Array.isArray(sanitized)
+    ? sanitized as Record<string, unknown>
+    : undefined;
+}
+
+function sanitizeValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sanitizeValue);
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([key, nested]) => {
+      if (isCredentialKey(key)) return [];
+      return [[key, sanitizeValue(nested)]];
+    }),
+  );
+}
+
+function isCredentialKey(key: string): boolean {
+  const normalized = key.toLowerCase().replaceAll('_', '').replaceAll('-', '');
+  return [
+    'credential',
+    'credentialjson',
+    'privatekey',
+    'serviceaccount',
+    'serviceaccountjson',
+  ].includes(normalized);
+}
+
+function filterEntries(
+  entries: ReadonlyArray<ActivityLogEntry>,
+  request?: ActivityLogListRequest,
+): ReadonlyArray<ActivityLogEntry> {
+  const search = request?.search?.trim().toLowerCase() ?? '';
+  return entries.filter((entry) => {
+    if (request?.area && request.area !== 'all' && entry.area !== request.area) return false;
+    if (request?.status && request.status !== 'all' && entry.status !== request.status) {
+      return false;
+    }
+    if (!search) return true;
+    return [
+      entry.action,
+      entry.area,
+      entry.status,
+      entry.summary,
+      entry.target?.label,
+      entry.target?.path,
+      entry.target?.uid,
+      entry.error?.message,
+    ].some((value) => value?.toLowerCase().includes(search));
+  }).slice(0, request?.limit ?? entries.length);
+}
+
+function byteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf8');
+}
+
+function reverseEntries(
+  entries: ReadonlyArray<ActivityLogEntry>,
+): ReadonlyArray<ActivityLogEntry> {
+  return entries.map((_, index) => entries[entries.length - index - 1]!);
+}
+
+export function activityErrorFrom(error: unknown, fallback: string): ActivityLogError {
+  if (error instanceof Error) return { message: error.message, name: error.name };
+  return { message: fallback };
+}

--- a/apps/desktop/src/main/app/data-mode.test.ts
+++ b/apps/desktop/src/main/app/data-mode.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_ACTIVITY_LOG_SETTINGS,
+  DEFAULT_FIRESTORE_WRITE_SETTINGS,
   type SettingsSnapshot,
 } from '@firebase-desk/repo-contracts';
 import { describe, expect, it } from 'vitest';
@@ -14,6 +15,7 @@ const snapshot: SettingsSnapshot = {
   hotkeyOverrides: {},
   resultTableLayouts: {},
   firestoreFieldCatalogs: {},
+  firestoreWrites: DEFAULT_FIRESTORE_WRITE_SETTINGS,
 };
 
 describe('data mode config', () => {

--- a/apps/desktop/src/main/app/data-mode.test.ts
+++ b/apps/desktop/src/main/app/data-mode.test.ts
@@ -1,8 +1,12 @@
-import type { SettingsSnapshot } from '@firebase-desk/repo-contracts';
+import {
+  DEFAULT_ACTIVITY_LOG_SETTINGS,
+  type SettingsSnapshot,
+} from '@firebase-desk/repo-contracts';
 import { describe, expect, it } from 'vitest';
 import { readDataModeSwitch, resolveDataMode } from './data-mode.ts';
 
 const snapshot: SettingsSnapshot = {
+  activityLog: DEFAULT_ACTIVITY_LOG_SETTINGS,
   sidebarWidth: 320,
   inspectorWidth: 360,
   theme: 'system',

--- a/apps/desktop/src/main/ipc/registry.ts
+++ b/apps/desktop/src/main/ipc/registry.ts
@@ -31,9 +31,11 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { MainActivityLogRepository } from '../activity/main-activity-log-repository.ts';
 import { resolveDataMode } from '../app/data-mode.ts';
 import { MainProjectsRepository } from '../projects/main-projects-repository.ts';
 import { MainSettingsRepository } from '../settings/main-settings-repository.ts';
+import { ActivityLogStore } from '../storage/activity-log-store.ts';
 import { CredentialsStore } from '../storage/credentials-store.ts';
 import { ProjectsStore } from '../storage/projects-store.ts';
 import { SettingsStore } from '../storage/settings-store.ts';
@@ -55,6 +57,23 @@ const ipcLogger: IpcLogger = {
 export function registerIpcHandlers(): void {
   const userDataPath = app.getPath('userData');
   const settingsRepository = new MainSettingsRepository(new SettingsStore(userDataPath));
+  const activityLogRepository = new MainActivityLogRepository(
+    new ActivityLogStore(userDataPath),
+    settingsRepository,
+    {
+      showSaveDialog: () =>
+        process.env['FIREBASE_DESK_ACTIVITY_EXPORT_PATH']
+          ? Promise.resolve({
+            canceled: false,
+            filePath: process.env['FIREBASE_DESK_ACTIVITY_EXPORT_PATH'],
+          })
+          : dialog.showSaveDialog({
+            defaultPath: 'firebase-desk-activity.jsonl',
+            filters: [{ name: 'JSON Lines', extensions: ['jsonl'] }],
+            title: 'Export activity',
+          }),
+    },
+  );
   const projectsStore = new ProjectsStore(userDataPath);
   const credentialsStore = new CredentialsStore(userDataPath);
   const projectsRepository = new MainProjectsRepository(projectsStore, credentialsStore);
@@ -91,6 +110,12 @@ export function registerIpcHandlers(): void {
       const errorMessage = await shell.openPath(userDataPath);
       if (errorMessage) throw new Error(errorMessage);
     },
+    'activity.append': (request) => activityLogRepository.append(request),
+    'activity.clear': async () => {
+      await activityLogRepository.clear();
+    },
+    'activity.export': (request) => activityLogRepository.export(request),
+    'activity.list': async (request) => [...await activityLogRepository.list(request)],
     'projects.list': async () => [...await projectsRepository.list()],
     'projects.get': ({ id }) => projectsRepository.get(id),
     'projects.add': (request) => projectsRepository.add(request),
@@ -172,7 +197,11 @@ export function registerIpcHandlers(): void {
     'auth.setCustomClaims': async ({ claims, projectId, uid }) =>
       toIpcAuthUser(await authRepository.setCustomClaims(projectId, uid, claims)),
     'settings.load': () => settingsRepository.load(),
-    'settings.save': (request) => settingsRepository.save(request),
+    'settings.save': async (request) => {
+      const snapshot = await settingsRepository.save(request);
+      if (request.activityLog?.maxBytes !== undefined) await activityLogRepository.prune();
+      return snapshot;
+    },
     'settings.getHotkeyOverrides': () => settingsRepository.getHotkeyOverrides(),
     'settings.setHotkeyOverrides': async (request) => {
       await settingsRepository.setHotkeyOverrides(request);

--- a/apps/desktop/src/main/ipc/registry.ts
+++ b/apps/desktop/src/main/ipc/registry.ts
@@ -10,7 +10,9 @@ import type {
   FirestoreCollectionNode,
   FirestoreDocumentNode,
   FirestoreDocumentResult,
+  FirestoreFieldPatchOperation,
   FirestoreQuery,
+  FirestoreRepository,
   FirestoreSaveDocumentOptions,
   FirestoreSaveDocumentResult,
   Page,
@@ -178,6 +180,20 @@ export function registerIpcHandlers(): void {
           toSaveDocumentOptions(options),
         ),
       ),
+    'firestore.updateDocumentFields': async (
+      { connectionId, documentPath, operations, options },
+    ) =>
+      toIpcUpdateDocumentFieldsResult(
+        await firestoreRepository.updateDocumentFields(
+          connectionId,
+          documentPath,
+          operations.map(toFieldPatchOperation),
+          {
+            staleBehavior: options.staleBehavior,
+            ...(options.lastUpdateTime ? { lastUpdateTime: options.lastUpdateTime } : {}),
+          },
+        ),
+      ),
     'firestore.deleteDocument': async ({ connectionId, documentPath, options }) => {
       await firestoreRepository.deleteDocument(connectionId, documentPath, options);
     },
@@ -319,6 +335,23 @@ function toSaveDocumentOptions(
   return options?.lastUpdateTime ? { lastUpdateTime: options.lastUpdateTime } : undefined;
 }
 
+function toFieldPatchOperation(
+  operation: IpcRequest<'firestore.updateDocumentFields'>['operations'][number],
+): FirestoreFieldPatchOperation {
+  return operation.type === 'delete'
+    ? {
+      baseValue: operation.baseValue,
+      fieldPath: operation.fieldPath,
+      type: 'delete',
+    }
+    : {
+      baseValue: operation.baseValue,
+      fieldPath: operation.fieldPath,
+      type: 'set',
+      value: operation.value,
+    };
+}
+
 function toIpcResultPage(
   page: Page<FirestoreDocumentResult>,
 ): IpcResponse<'firestore.runQuery'> {
@@ -353,6 +386,22 @@ function toIpcSaveDocumentResult(
     };
   }
   return { status: 'saved', document: toIpcDocumentResult(result.document) };
+}
+
+function toIpcUpdateDocumentFieldsResult(
+  result: Awaited<ReturnType<FirestoreRepository['updateDocumentFields']>>,
+): IpcResponse<'firestore.updateDocumentFields'> {
+  if (result.status === 'conflict' || result.status === 'document-changed') {
+    return {
+      status: result.status,
+      remoteDocument: result.remoteDocument ? toIpcDocumentResult(result.remoteDocument) : null,
+    };
+  }
+  return {
+    status: 'saved',
+    document: toIpcDocumentResult(result.document),
+    ...(result.documentChanged ? { documentChanged: true } : {}),
+  };
 }
 
 function toIpcScriptRunResult(result: ScriptRunResult): IpcResponse<'scriptRunner.run'> {

--- a/apps/desktop/src/main/packaging/electron-vite-config.test.ts
+++ b/apps/desktop/src/main/packaging/electron-vite-config.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import packageJson from '../../../package.json';
+
+import { mainExternalizeDeps, workspaceRuntimePackages } from './main-externalize-deps';
+
+describe('electron vite config', () => {
+  it('bundles desktop workspace packages into the main process output', () => {
+    const workspaceDependencies = Object.keys(packageJson.dependencies)
+      .filter((packageName) => packageName.startsWith('@firebase-desk/'));
+    const workspaceDependencySet = new Set(workspaceDependencies);
+
+    expect(new Set(workspaceRuntimePackages)).toEqual(workspaceDependencySet);
+    expect(workspaceRuntimePackages).toHaveLength(workspaceDependencySet.size);
+    expect(new Set(mainExternalizeDeps.exclude)).toEqual(workspaceDependencySet);
+    expect(mainExternalizeDeps.exclude).toHaveLength(workspaceDependencySet.size);
+    expect(mainExternalizeDeps.include).toContain('firebase-admin');
+  });
+});

--- a/apps/desktop/src/main/packaging/main-externalize-deps.ts
+++ b/apps/desktop/src/main/packaging/main-externalize-deps.ts
@@ -1,0 +1,19 @@
+const workspaceRuntimePackages = [
+  '@firebase-desk/data-format',
+  '@firebase-desk/design-tokens',
+  '@firebase-desk/hotkeys',
+  '@firebase-desk/ipc-schemas',
+  '@firebase-desk/product-ui',
+  '@firebase-desk/repo-contracts',
+  '@firebase-desk/repo-firebase',
+  '@firebase-desk/repo-mocks',
+  '@firebase-desk/script-runner',
+  '@firebase-desk/ui',
+];
+
+const mainExternalizeDeps = {
+  exclude: workspaceRuntimePackages,
+  include: ['firebase-admin'],
+};
+
+export { mainExternalizeDeps, workspaceRuntimePackages };

--- a/apps/desktop/src/main/settings/main-settings-repository.test.ts
+++ b/apps/desktop/src/main/settings/main-settings-repository.test.ts
@@ -1,8 +1,12 @@
-import type { SettingsSnapshot } from '@firebase-desk/repo-contracts';
+import {
+  DEFAULT_ACTIVITY_LOG_SETTINGS,
+  type SettingsSnapshot,
+} from '@firebase-desk/repo-contracts';
 import { describe, expect, it } from 'vitest';
 import { MainSettingsRepository } from './main-settings-repository.ts';
 
 const initialSnapshot: SettingsSnapshot = {
+  activityLog: DEFAULT_ACTIVITY_LOG_SETTINGS,
   sidebarWidth: 320,
   inspectorWidth: 360,
   theme: 'system',

--- a/apps/desktop/src/main/settings/main-settings-repository.test.ts
+++ b/apps/desktop/src/main/settings/main-settings-repository.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_ACTIVITY_LOG_SETTINGS,
+  DEFAULT_FIRESTORE_WRITE_SETTINGS,
   type SettingsSnapshot,
 } from '@firebase-desk/repo-contracts';
 import { describe, expect, it } from 'vitest';
@@ -14,6 +15,7 @@ const initialSnapshot: SettingsSnapshot = {
   hotkeyOverrides: { 'query.run': 'Meta+Enter' },
   resultTableLayouts: {},
   firestoreFieldCatalogs: {},
+  firestoreWrites: DEFAULT_FIRESTORE_WRITE_SETTINGS,
 };
 
 describe('MainSettingsRepository', () => {

--- a/apps/desktop/src/main/settings/main-settings-repository.ts
+++ b/apps/desktop/src/main/settings/main-settings-repository.ts
@@ -1,4 +1,5 @@
 import type {
+  ActivityLogSettings,
   HotkeyOverrides,
   SettingsPatch,
   SettingsRepository,
@@ -24,6 +25,9 @@ export class MainSettingsRepository implements SettingsRepository {
   async save(patch: SettingsPatch): Promise<SettingsSnapshot> {
     const current = await this.store.load();
     return await this.store.save({
+      activityLog: patch.activityLog
+        ? cloneActivityLogSettings(patch.activityLog)
+        : cloneActivityLogSettings(current.activityLog),
       sidebarWidth: patch.sidebarWidth ?? current.sidebarWidth,
       inspectorWidth: patch.inspectorWidth ?? current.inspectorWidth,
       theme: patch.theme ?? current.theme,
@@ -47,6 +51,10 @@ export class MainSettingsRepository implements SettingsRepository {
   async setHotkeyOverrides(overrides: HotkeyOverrides): Promise<void> {
     await this.save({ hotkeyOverrides: { ...overrides } });
   }
+}
+
+function cloneActivityLogSettings(settings: ActivityLogSettings): ActivityLogSettings {
+  return { ...settings };
 }
 
 function cloneResultTableLayouts(

--- a/apps/desktop/src/main/settings/main-settings-repository.ts
+++ b/apps/desktop/src/main/settings/main-settings-repository.ts
@@ -5,6 +5,7 @@ import type {
   SettingsRepository,
   SettingsSnapshot,
 } from '@firebase-desk/repo-contracts';
+import { normalizeFirestoreWriteSettings } from '@firebase-desk/repo-contracts';
 
 interface SettingsStoreLike {
   readonly load: () => Promise<SettingsSnapshot>;
@@ -41,6 +42,9 @@ export class MainSettingsRepository implements SettingsRepository {
       firestoreFieldCatalogs: patch.firestoreFieldCatalogs
         ? cloneFirestoreFieldCatalogs(patch.firestoreFieldCatalogs)
         : cloneFirestoreFieldCatalogs(current.firestoreFieldCatalogs),
+      firestoreWrites: normalizeFirestoreWriteSettings(
+        patch.firestoreWrites ?? current.firestoreWrites,
+      ),
     });
   }
 

--- a/apps/desktop/src/main/storage/activity-log-store.test.ts
+++ b/apps/desktop/src/main/storage/activity-log-store.test.ts
@@ -1,0 +1,86 @@
+import type { ActivityLogEntry } from '@firebase-desk/repo-contracts';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ActivityLogStore } from './activity-log-store.ts';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
+});
+
+describe('ActivityLogStore', () => {
+  it('appends and lists newest first', async () => {
+    const dir = await makeTempDir();
+    const store = new ActivityLogStore(dir);
+
+    await store.append(entry('one', '2026-04-29T00:00:00.000Z'), 1024 * 1024);
+    await store.append(entry('two', '2026-04-29T00:00:01.000Z'), 1024 * 1024);
+
+    await expect(store.list()).resolves.toMatchObject([
+      { id: 'two' },
+      { id: 'one' },
+    ]);
+  });
+
+  it('prunes oldest entries by byte budget', async () => {
+    const dir = await makeTempDir();
+    const store = new ActivityLogStore(dir);
+    await store.append(entry('one', '2026-04-29T00:00:00.000Z', 'x'.repeat(200)), 1024 * 1024);
+    await store.append(entry('two', '2026-04-29T00:00:01.000Z', 'x'.repeat(200)), 1024 * 1024);
+
+    await store.prune(
+      Buffer.byteLength(
+        `${JSON.stringify(entry('two', '2026-04-29T00:00:01.000Z', 'x'.repeat(200)))}\n`,
+        'utf8',
+      ),
+    );
+
+    await expect(store.list()).resolves.toMatchObject([{ id: 'two' }]);
+  });
+
+  it('skips invalid jsonl lines and clears', async () => {
+    const dir = await makeTempDir();
+    await writeFile(
+      join(dir, 'activity-log.jsonl'),
+      `bad json\n${JSON.stringify(entry('valid', '2026-04-29T00:00:00.000Z'))}\n`,
+      'utf8',
+    );
+    const store = new ActivityLogStore(dir);
+
+    await expect(store.list()).resolves.toMatchObject([{ id: 'valid' }]);
+
+    await store.clear();
+
+    await expect(store.list()).resolves.toEqual([]);
+  });
+
+  it('exports JSONL', async () => {
+    const dir = await makeTempDir();
+    const store = new ActivityLogStore(dir);
+    const exportPath = join(dir, 'export.jsonl');
+
+    await store.exportTo(exportPath, [entry('one', '2026-04-29T00:00:00.000Z')]);
+
+    expect(await readFile(exportPath, 'utf8')).toContain('"id":"one"');
+  });
+});
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'firebase-desk-activity-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function entry(id: string, timestamp: string, summary = 'Saved'): ActivityLogEntry {
+  return {
+    action: 'Save document',
+    area: 'firestore',
+    id,
+    status: 'success',
+    summary,
+    timestamp,
+  };
+}

--- a/apps/desktop/src/main/storage/activity-log-store.test.ts
+++ b/apps/desktop/src/main/storage/activity-log-store.test.ts
@@ -25,6 +25,24 @@ describe('ActivityLogStore', () => {
     ]);
   });
 
+  it('serializes concurrent appends without losing entries', async () => {
+    const dir = await makeTempDir();
+    const store = new ActivityLogStore(dir);
+
+    await Promise.all(
+      Array.from(
+        { length: 25 },
+        (_, index) =>
+          store.append(
+            entry(`entry-${index}`, `2026-04-29T00:00:${String(index).padStart(2, '0')}.000Z`),
+            1024 * 1024,
+          ),
+      ),
+    );
+
+    await expect(store.list()).resolves.toHaveLength(25);
+  });
+
   it('prunes oldest entries by byte budget', async () => {
     const dir = await makeTempDir();
     const store = new ActivityLogStore(dir);

--- a/apps/desktop/src/main/storage/activity-log-store.ts
+++ b/apps/desktop/src/main/storage/activity-log-store.ts
@@ -1,0 +1,89 @@
+import { ActivityLogEntrySchema } from '@firebase-desk/ipc-schemas';
+import type { ActivityLogEntry } from '@firebase-desk/repo-contracts';
+import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+export class ActivityLogStore {
+  private readonly filePath: string;
+
+  constructor(userDataPath: string) {
+    this.filePath = join(userDataPath, 'activity-log.jsonl');
+  }
+
+  async append(entry: ActivityLogEntry, maxBytes: number): Promise<void> {
+    const entries = [...await this.readEntriesOldestFirst(), entry];
+    await this.writeEntries(pruneEntries(entries, maxBytes));
+  }
+
+  async clear(): Promise<void> {
+    try {
+      await unlink(this.filePath);
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+    }
+  }
+
+  async exportTo(filePath: string, entries?: ReadonlyArray<ActivityLogEntry>): Promise<void> {
+    await writeFile(filePath, jsonl(entries ?? await this.readEntriesOldestFirst()), 'utf8');
+  }
+
+  async list(): Promise<ReadonlyArray<ActivityLogEntry>> {
+    return reverseEntries(await this.readEntriesOldestFirst());
+  }
+
+  async prune(maxBytes: number): Promise<void> {
+    await this.writeEntries(pruneEntries(await this.readEntriesOldestFirst(), maxBytes));
+  }
+
+  private async readEntriesOldestFirst(): Promise<ReadonlyArray<ActivityLogEntry>> {
+    try {
+      const raw = await readFile(this.filePath, 'utf8');
+      return raw.split('\n').flatMap((line) => {
+        if (!line.trim()) return [];
+        try {
+          const parsed = ActivityLogEntrySchema.safeParse(JSON.parse(line) as unknown);
+          return parsed.success ? [parsed.data] : [];
+        } catch {
+          return [];
+        }
+      });
+    } catch (error) {
+      if (isNotFound(error)) return [];
+      throw error;
+    }
+  }
+
+  private async writeEntries(entries: ReadonlyArray<ActivityLogEntry>): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    const content = entries.map((entry) => JSON.stringify(entry)).join('\n');
+    await writeFile(this.filePath, content ? `${content}\n` : '', 'utf8');
+  }
+}
+
+function pruneEntries(
+  entries: ReadonlyArray<ActivityLogEntry>,
+  maxBytes: number,
+): ReadonlyArray<ActivityLogEntry> {
+  const next = [...entries];
+  while (next.length > 0 && byteLength(jsonl(next)) > maxBytes) next.shift();
+  return next;
+}
+
+function jsonl(entries: ReadonlyArray<ActivityLogEntry>): string {
+  const content = entries.map((entry) => JSON.stringify(entry)).join('\n');
+  return content ? `${content}\n` : '';
+}
+
+function byteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf8');
+}
+
+function isNotFound(error: unknown): boolean {
+  return Boolean(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT');
+}
+
+function reverseEntries(
+  entries: ReadonlyArray<ActivityLogEntry>,
+): ReadonlyArray<ActivityLogEntry> {
+  return entries.map((_, index) => entries[entries.length - index - 1]!);
+}

--- a/apps/desktop/src/main/storage/activity-log-store.ts
+++ b/apps/desktop/src/main/storage/activity-log-store.ts
@@ -5,34 +5,43 @@ import { dirname, join } from 'node:path';
 
 export class ActivityLogStore {
   private readonly filePath: string;
+  private mutationQueue: Promise<void> = Promise.resolve();
 
   constructor(userDataPath: string) {
     this.filePath = join(userDataPath, 'activity-log.jsonl');
   }
 
   async append(entry: ActivityLogEntry, maxBytes: number): Promise<void> {
-    const entries = [...await this.readEntriesOldestFirst(), entry];
-    await this.writeEntries(pruneEntries(entries, maxBytes));
+    await this.runMutation(async () => {
+      const entries = [...await this.readEntriesOldestFirst(), entry];
+      await this.writeEntries(pruneEntries(entries, maxBytes));
+    });
   }
 
   async clear(): Promise<void> {
-    try {
-      await unlink(this.filePath);
-    } catch (error) {
-      if (!isNotFound(error)) throw error;
-    }
+    await this.runMutation(async () => {
+      try {
+        await unlink(this.filePath);
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
+      }
+    });
   }
 
   async exportTo(filePath: string, entries?: ReadonlyArray<ActivityLogEntry>): Promise<void> {
+    await this.waitForMutations();
     await writeFile(filePath, jsonl(entries ?? await this.readEntriesOldestFirst()), 'utf8');
   }
 
   async list(): Promise<ReadonlyArray<ActivityLogEntry>> {
+    await this.waitForMutations();
     return reverseEntries(await this.readEntriesOldestFirst());
   }
 
   async prune(maxBytes: number): Promise<void> {
-    await this.writeEntries(pruneEntries(await this.readEntriesOldestFirst(), maxBytes));
+    await this.runMutation(async () => {
+      await this.writeEntries(pruneEntries(await this.readEntriesOldestFirst(), maxBytes));
+    });
   }
 
   private async readEntriesOldestFirst(): Promise<ReadonlyArray<ActivityLogEntry>> {
@@ -58,15 +67,30 @@ export class ActivityLogStore {
     const content = entries.map((entry) => JSON.stringify(entry)).join('\n');
     await writeFile(this.filePath, content ? `${content}\n` : '', 'utf8');
   }
+
+  private runMutation(operation: () => Promise<void>): Promise<void> {
+    const next = this.mutationQueue.then(operation, operation);
+    this.mutationQueue = next.catch(() => undefined);
+    return next;
+  }
+
+  private async waitForMutations(): Promise<void> {
+    await this.mutationQueue.catch(() => undefined);
+  }
 }
 
 function pruneEntries(
   entries: ReadonlyArray<ActivityLogEntry>,
   maxBytes: number,
 ): ReadonlyArray<ActivityLogEntry> {
-  const next = [...entries];
-  while (next.length > 0 && byteLength(jsonl(next)) > maxBytes) next.shift();
-  return next;
+  const sizes = entries.map((entry) => byteLength(`${JSON.stringify(entry)}\n`));
+  let totalBytes = sizes.reduce((total, size) => total + size, 0);
+  let startIndex = 0;
+  while (startIndex < entries.length && totalBytes > maxBytes) {
+    totalBytes -= sizes[startIndex]!;
+    startIndex += 1;
+  }
+  return entries.slice(startIndex);
 }
 
 function jsonl(entries: ReadonlyArray<ActivityLogEntry>): string {

--- a/apps/desktop/src/main/storage/settings-store.ts
+++ b/apps/desktop/src/main/storage/settings-store.ts
@@ -1,10 +1,15 @@
 import { SettingsFileSchema } from '@firebase-desk/ipc-schemas';
-import type { SettingsSnapshot } from '@firebase-desk/repo-contracts';
+import {
+  type ActivityLogSettings,
+  DEFAULT_ACTIVITY_LOG_SETTINGS,
+  type SettingsSnapshot,
+} from '@firebase-desk/repo-contracts';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { writeJsonAtomic } from './atomic-write.ts';
 
 export const DEFAULT_SETTINGS_SNAPSHOT: SettingsSnapshot = {
+  activityLog: DEFAULT_ACTIVITY_LOG_SETTINGS,
   sidebarWidth: 320,
   inspectorWidth: 360,
   theme: 'system',
@@ -51,6 +56,7 @@ export class SettingsStore {
 function cloneSnapshot(snapshot: SettingsSnapshot): SettingsSnapshot {
   return {
     ...snapshot,
+    activityLog: cloneActivityLogSettings(snapshot.activityLog),
     hotkeyOverrides: { ...snapshot.hotkeyOverrides },
     firestoreFieldCatalogs: Object.fromEntries(
       Object.entries(snapshot.firestoreFieldCatalogs).map(([key, entries]) => [
@@ -72,6 +78,10 @@ function cloneSnapshot(snapshot: SettingsSnapshot): SettingsSnapshot {
       ]),
     ),
   };
+}
+
+function cloneActivityLogSettings(settings: ActivityLogSettings): ActivityLogSettings {
+  return { ...settings };
 }
 
 function isNotFound(error: unknown): boolean {

--- a/apps/desktop/src/main/storage/settings-store.ts
+++ b/apps/desktop/src/main/storage/settings-store.ts
@@ -2,6 +2,8 @@ import { SettingsFileSchema } from '@firebase-desk/ipc-schemas';
 import {
   type ActivityLogSettings,
   DEFAULT_ACTIVITY_LOG_SETTINGS,
+  DEFAULT_FIRESTORE_WRITE_SETTINGS,
+  normalizeFirestoreWriteSettings,
   type SettingsSnapshot,
 } from '@firebase-desk/repo-contracts';
 import { readFile } from 'node:fs/promises';
@@ -17,6 +19,7 @@ export const DEFAULT_SETTINGS_SNAPSHOT: SettingsSnapshot = {
   hotkeyOverrides: {},
   resultTableLayouts: {},
   firestoreFieldCatalogs: {},
+  firestoreWrites: DEFAULT_FIRESTORE_WRITE_SETTINGS,
 };
 
 export class SettingsStore {
@@ -57,6 +60,7 @@ function cloneSnapshot(snapshot: SettingsSnapshot): SettingsSnapshot {
   return {
     ...snapshot,
     activityLog: cloneActivityLogSettings(snapshot.activityLog),
+    firestoreWrites: normalizeFirestoreWriteSettings(snapshot.firestoreWrites),
     hotkeyOverrides: { ...snapshot.hotkeyOverrides },
     firestoreFieldCatalogs: Object.fromEntries(
       Object.entries(snapshot.firestoreFieldCatalogs).map(([key, entries]) => [

--- a/apps/desktop/src/preload/index.test.ts
+++ b/apps/desktop/src/preload/index.test.ts
@@ -83,6 +83,16 @@ describe('preload script runner api', () => {
           updateTime: '2026-04-29T00:00:00.000Z',
         },
       })
+      .mockResolvedValueOnce({
+        status: 'saved',
+        document: {
+          id: 'ord_1',
+          path: 'orders/ord_1',
+          data: { status: 'shipped' },
+          hasSubcollections: false,
+          updateTime: '2026-04-29T00:00:01.000Z',
+        },
+      })
       .mockResolvedValueOnce(undefined);
 
     await expect(api.firestore.generateDocumentId({
@@ -100,6 +110,17 @@ describe('preload script runner api', () => {
       documentPath: 'orders/ord_1',
       data: { status: 'paid' },
       options: { lastUpdateTime: '2026-04-29T00:00:00.000Z' },
+    })).resolves.toMatchObject({ status: 'saved', document: { id: 'ord_1' } });
+    await expect(api.firestore.updateDocumentFields({
+      connectionId: 'emu',
+      documentPath: 'orders/ord_1',
+      operations: [
+        { baseValue: 'paid', fieldPath: ['status'], type: 'set', value: 'shipped' },
+      ],
+      options: {
+        lastUpdateTime: '2026-04-29T00:00:00.000Z',
+        staleBehavior: 'save-and-notify',
+      },
     })).resolves.toMatchObject({ status: 'saved', document: { id: 'ord_1' } });
     await expect(api.firestore.deleteDocument({
       connectionId: 'emu',
@@ -122,6 +143,17 @@ describe('preload script runner api', () => {
       documentPath: 'orders/ord_1',
       data: { status: 'paid' },
       options: { lastUpdateTime: '2026-04-29T00:00:00.000Z' },
+    });
+    expect(electronMocks.invoke).toHaveBeenCalledWith('firestore.updateDocumentFields', {
+      connectionId: 'emu',
+      documentPath: 'orders/ord_1',
+      operations: [
+        { baseValue: 'paid', fieldPath: ['status'], type: 'set', value: 'shipped' },
+      ],
+      options: {
+        lastUpdateTime: '2026-04-29T00:00:00.000Z',
+        staleBehavior: 'save-and-notify',
+      },
     });
     expect(electronMocks.invoke).toHaveBeenCalledWith('firestore.deleteDocument', {
       connectionId: 'emu',

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -60,6 +60,8 @@ const api = {
       invoke('firestore.createDocument', request),
     saveDocument: (request: IpcRequest<'firestore.saveDocument'>) =>
       invoke('firestore.saveDocument', request),
+    updateDocumentFields: (request: IpcRequest<'firestore.updateDocumentFields'>) =>
+      invoke('firestore.updateDocumentFields', request),
     deleteDocument: (request: IpcRequest<'firestore.deleteDocument'>) =>
       invoke('firestore.deleteDocument', request),
   },

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -21,6 +21,12 @@ const api = {
   health: {
     check: (request: IpcRequest<'health.check'>) => invoke('health.check', request),
   },
+  activity: {
+    append: (request: IpcRequest<'activity.append'>) => invoke('activity.append', request),
+    clear: () => invoke('activity.clear', {}),
+    export: (request: IpcRequest<'activity.export'>) => invoke('activity.export', request),
+    list: (request: IpcRequest<'activity.list'>) => invoke('activity.list', request),
+  },
   projects: {
     list: () => invoke('projects.list', {}),
     get: (request: IpcRequest<'projects.get'>) => invoke('projects.get', request),

--- a/apps/desktop/src/renderer/app/App.test.tsx
+++ b/apps/desktop/src/renderer/app/App.test.tsx
@@ -49,6 +49,11 @@ describe('desktop App', () => {
 
   it('shows the app shell after settings load', async () => {
     settingsLoad.mockResolvedValue({
+      activityLog: {
+        detailMode: 'metadata',
+        enabled: true,
+        maxBytes: 5 * 1024 * 1024,
+      },
       sidebarWidth: 280,
       inspectorWidth: 360,
       theme: 'system',

--- a/apps/desktop/src/renderer/app/App.test.tsx
+++ b/apps/desktop/src/renderer/app/App.test.tsx
@@ -61,6 +61,7 @@ describe('desktop App', () => {
       hotkeyOverrides: {},
       resultTableLayouts: {},
       firestoreFieldCatalogs: {},
+      firestoreWrites: { fieldStaleBehavior: 'save-and-notify' },
     });
 
     render(<App />);

--- a/apps/desktop/src/renderer/app/AppShell.firestoreWrites.test.tsx
+++ b/apps/desktop/src/renderer/app/AppShell.firestoreWrites.test.tsx
@@ -13,7 +13,7 @@ import {
 import { selectionActions, selectionStore } from './stores/selectionStore.ts';
 import { tabActions } from './stores/tabsStore.ts';
 
-type MockSurfaceAction = 'create' | 'delete' | 'save';
+type MockSurfaceAction = 'create' | 'delete' | 'patch' | 'save';
 
 interface MockSurfaceProps {
   readonly onCreateDocument?: (
@@ -32,6 +32,16 @@ interface MockSurfaceProps {
     documentPath: string,
     data: Record<string, unknown>,
     options?: { readonly lastUpdateTime?: string; },
+  ) => Promise<unknown> | unknown;
+  readonly onUpdateDocumentFields?: (
+    documentPath: string,
+    operations: ReadonlyArray<{
+      readonly baseValue: unknown;
+      readonly fieldPath: ReadonlyArray<string>;
+      readonly type: 'delete' | 'set';
+      readonly value?: unknown;
+    }>,
+    options: { readonly lastUpdateTime?: string; readonly staleBehavior: 'save-and-notify'; },
   ) => Promise<unknown> | unknown;
 }
 
@@ -61,6 +71,15 @@ vi.mock('@firebase-desk/product-ui', async (importOriginal) => {
                 deleteDescendantDocumentPaths: ['orders/ord_1024/events/event_1'],
                 deleteSubcollectionPaths: ['orders/ord_1024/events'],
               });
+              return;
+            }
+            if (surfaceState.action === 'patch') {
+              void props.onUpdateDocumentFields?.('orders/ord_1024', [{
+                baseValue: 'draft',
+                fieldPath: ['status'],
+                type: 'set',
+                value: 'paid',
+              }], { staleBehavior: 'save-and-notify' });
               return;
             }
             void props.onSaveDocument?.('orders/ord_1024', { status: 'paid' });
@@ -200,6 +219,34 @@ describe('desktop AppShell Firestore writes', () => {
       expect(createDocument).toHaveBeenCalledWith('emu', 'orders', 'ord_created', {
         status: 'new',
       })
+    );
+    await waitFor(() =>
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['firestore'] })
+    );
+  });
+
+  it('updates Firestore fields through patch writes and invalidates live Firestore queries', async () => {
+    surfaceState.action = 'patch';
+    const repositories = createMockRepositories();
+    const updateDocumentFields = vi.spyOn(repositories.firestore, 'updateDocumentFields');
+    const { queryClient } = renderShell({ dataMode: 'live', repositories });
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+
+    await waitFor(() => expect(screen.getAllByText('Local Emulator').length).toBeGreaterThan(0));
+    fireEvent.click(await screen.findByRole('button', { name: 'Trigger Firestore write' }));
+
+    await waitFor(() =>
+      expect(updateDocumentFields).toHaveBeenCalledWith(
+        'emu',
+        'orders/ord_1024',
+        [{
+          baseValue: 'draft',
+          fieldPath: ['status'],
+          type: 'set',
+          value: 'paid',
+        }],
+        { staleBehavior: 'save-and-notify' },
+      )
     );
     await waitFor(() =>
       expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['firestore'] })

--- a/apps/desktop/src/renderer/app/AppShell.test.tsx
+++ b/apps/desktop/src/renderer/app/AppShell.test.tsx
@@ -125,6 +125,42 @@ describe('desktop AppShell', () => {
     expect(await screen.findByText('Change theme')).toBeTruthy();
   });
 
+  it('clears the activity issue indicator when Activity is opened', async () => {
+    const repositories = createMockRepositories();
+    await repositories.activity.append({
+      action: 'Run query',
+      area: 'firestore',
+      status: 'failure',
+      summary: 'Failed to load orders',
+    });
+    renderShell({ repositories });
+
+    const activityButton = await screen.findByRole('button', { name: /Activity.*failure/ });
+    fireEvent.click(activityButton);
+
+    await waitFor(() => expect(activityButton.textContent).not.toContain('failure'));
+  });
+
+  it('keeps the activity issue indicator until Activity is opened', async () => {
+    const repositories = createMockRepositories();
+    await repositories.activity.append({
+      action: 'Run query',
+      area: 'firestore',
+      status: 'failure',
+      summary: 'Failed to load orders',
+    });
+    renderShell({ repositories });
+
+    const activityButton = await screen.findByRole('button', { name: /Activity.*failure/ });
+    fireEvent.click(screen.getByRole('button', { name: 'Dark theme' }));
+
+    await waitFor(() => expect(activityButton.textContent).toContain('failure'));
+
+    fireEvent.click(activityButton);
+
+    await waitFor(() => expect(activityButton.textContent).not.toContain('failure'));
+  });
+
   it('records Firestore query activity', async () => {
     const repositories = createMockRepositories();
     const appendActivity = vi.spyOn(repositories.activity, 'append');

--- a/apps/desktop/src/renderer/app/AppShell.test.tsx
+++ b/apps/desktop/src/renderer/app/AppShell.test.tsx
@@ -114,6 +114,35 @@ describe('desktop AppShell', () => {
     await waitFor(() => expect(document.documentElement.dataset.theme).toBe('dark'));
   });
 
+  it('records settings activity and shows it in the drawer', async () => {
+    const repositories = createMockRepositories();
+    renderShell({ repositories });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dark theme' }));
+    fireEvent.click(screen.getByRole('button', { name: /Activity/ }));
+
+    expect(await screen.findByRole('region', { name: 'Activity' })).toBeTruthy();
+    expect(await screen.findByText('Change theme')).toBeTruthy();
+  });
+
+  it('records Firestore query activity', async () => {
+    const repositories = createMockRepositories();
+    const appendActivity = vi.spyOn(repositories.activity, 'append');
+    renderShell({ initialTab: { kind: 'firestore-query', connectionId: 'emu' }, repositories });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
+
+    await waitFor(() =>
+      expect(appendActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'Run query',
+          area: 'firestore',
+          status: 'success',
+        }),
+      )
+    );
+  });
+
   it('shows real add account fields for service accounts and emulator profiles', async () => {
     renderShell();
     fireEvent.click(screen.getByRole('button', { name: 'Add account' }));

--- a/apps/desktop/src/renderer/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/app/AppShell.tsx
@@ -2,6 +2,7 @@ import type { AppearanceMode, DensityName } from '@firebase-desk/design-tokens';
 import { useHotkey } from '@firebase-desk/hotkeys';
 import {
   AccountTree,
+  ActivityDrawer,
   AuthUsersSurface,
   CommandPalette,
   type DeleteDocumentOptions,
@@ -19,6 +20,11 @@ import {
   WorkspaceTabStrip,
 } from '@firebase-desk/product-ui';
 import type {
+  ActivityLogAppendInput,
+  ActivityLogArea,
+  ActivityLogEntry,
+  ActivityLogListRequest,
+  ActivityLogStatus,
   AuthUser,
   FirestoreCollectionNode,
   FirestoreDocumentResult,
@@ -28,6 +34,7 @@ import type {
   ProjectSummary,
   ProjectUpdatePatch,
   ScriptRunResult,
+  SettingsPatch,
 } from '@firebase-desk/repo-contracts';
 import {
   Badge,
@@ -51,6 +58,7 @@ import {
   ArrowLeft,
   ArrowRight,
   Database,
+  ListChecks,
   Moon,
   PanelLeftClose,
   PanelLeftOpen,
@@ -60,7 +68,7 @@ import {
   Sun,
   X,
 } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import appIconUrl from '../assets/app-icon.png';
 import { AddProjectDialog } from './dialogs/AddProjectDialog.tsx';
 import { EditProjectDialog } from './dialogs/EditProjectDialog.tsx';
@@ -143,6 +151,14 @@ export function AppShell(
   const [editingProjectId, setEditingProjectId] = useState<string | null>(null);
   const [credentialWarning, setCredentialWarning] = useState<string | null>(null);
   const [lastAction, setLastAction] = useState('Ready');
+  const [activityOpen, setActivityOpen] = useState(false);
+  const [activityExpanded, setActivityExpanded] = useState(false);
+  const [activityEntries, setActivityEntries] = useState<ReadonlyArray<ActivityLogEntry>>([]);
+  const [activitySearch, setActivitySearch] = useState('');
+  const [activityArea, setActivityArea] = useState<ActivityLogArea | 'all'>('all');
+  const [activityStatus, setActivityStatus] = useState<ActivityLogStatus | 'all'>('all');
+  const [activityIsLoading, setActivityIsLoading] = useState(false);
+  const [latestActivityIssue, setLatestActivityIssue] = useState<ActivityLogEntry | null>(null);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [pendingDestructiveAction, setPendingDestructiveAction] = useState<
     DestructiveAction | null
@@ -151,6 +167,11 @@ export function AppShell(
     PendingCreateDocumentRequest | null
   >(null);
   const nextCreateDocumentRequestId = useRef(1);
+  const loggedFirestoreRuns = useRef<Set<string>>(new Set());
+  const loggedScriptRuns = useRef<Set<string>>(new Set());
+  const loggedAuthFailures = useRef<Set<string>>(new Set());
+  const activityOpenRef = useRef(false);
+  const activityListRequestRef = useRef<ActivityLogListRequest>({ limit: 200 });
   const firestoreTab = useFirestoreTabState({
     activeProject,
     activeTab,
@@ -182,10 +203,61 @@ export function AppShell(
     ? projects.find((project) => project.id === editingProjectId) ?? null
     : null;
   const sidebarDefaultWidth = clampSidebarWidth(initialSidebarWidth);
+  const activityListRequest = useMemo<ActivityLogListRequest>(() => ({
+    area: activityArea,
+    limit: 200,
+    search: activitySearch.trim() || undefined,
+    status: activityStatus,
+  }), [activityArea, activitySearch, activityStatus]);
+
+  const loadActivity = useCallback(async () => {
+    setActivityIsLoading(true);
+    try {
+      const entries = await repositories.activity.list(activityListRequest);
+      setActivityEntries(entries);
+      setLatestActivityIssue(entries.find(isActivityIssue) ?? null);
+    } catch (error) {
+      setLastAction(`Activity load failed: ${messageFromError(error, 'Could not load activity.')}`);
+    } finally {
+      setActivityIsLoading(false);
+    }
+  }, [activityListRequest, repositories.activity]);
+
+  const recordActivity = useCallback((input: ActivityLogAppendInput) => {
+    void repositories.activity.append(input)
+      .then((entry) => {
+        if (isActivityIssue(entry)) setLatestActivityIssue(entry);
+        setActivityEntries((current) =>
+          activityOpenRef.current
+            && activityEntryMatchesRequest(entry, activityListRequestRef.current)
+            ? [entry, ...current].slice(0, 200)
+            : current
+        );
+      })
+      .catch(() => {});
+  }, [repositories.activity]);
 
   useEffect(() => {
     document.documentElement.dataset.density = density;
   }, [density]);
+
+  useEffect(() => {
+    activityOpenRef.current = activityOpen;
+  }, [activityOpen]);
+
+  useEffect(() => {
+    activityListRequestRef.current = activityListRequest;
+  }, [activityListRequest]);
+
+  useEffect(() => {
+    void repositories.activity.list({ limit: 50 })
+      .then((entries) => setLatestActivityIssue(entries.find(isActivityIssue) ?? null))
+      .catch(() => {});
+  }, [repositories.activity]);
+
+  useEffect(() => {
+    if (activityOpen) void loadActivity();
+  }, [activityOpen, loadActivity]);
 
   useEffect(() => {
     savePersistedWorkspaceState({
@@ -217,6 +289,104 @@ export function AppShell(
     };
   }, [settingsOpen]);
 
+  useEffect(() => {
+    if (!activeTab || activeTab.kind !== 'firestore-query') return;
+    const runId = firestoreTab.activeQueryRunId;
+    const path = firestoreTab.activeQueryPath;
+    if (!runId || !path || firestoreTab.isLoading) return;
+
+    const key = `${activeTab.id}:${runId}`;
+    if (loggedFirestoreRuns.current.has(key)) return;
+    loggedFirestoreRuns.current.add(key);
+
+    const isDocument = firestoreTab.activeQueryIsDocument;
+    const errorMessage = firestoreTab.errorMessage;
+    recordActivity({
+      action: isDocument ? 'Read document' : 'Run query',
+      area: 'firestore',
+      ...(errorMessage ? { error: { message: errorMessage } } : {}),
+      metadata: {
+        loadedPages: firestoreTab.activeLoadedPageCount,
+        path,
+        resultCount: firestoreTab.queryRows.length,
+        ...queryDraftMetadata(firestoreTab.activeDraft),
+      },
+      status: errorMessage ? 'failure' : 'success',
+      summary: errorMessage
+        ? `Failed to load ${path}`
+        : `Loaded ${firestoreTab.queryRows.length} result${
+          firestoreTab.queryRows.length === 1 ? '' : 's'
+        } from ${path}`,
+      target: {
+        connectionId: activeTab.connectionId,
+        path,
+        type: isDocument ? 'firestore-document' : 'firestore-query',
+      },
+    });
+  }, [
+    activeTab,
+    firestoreTab.activeDraft,
+    firestoreTab.activeLoadedPageCount,
+    firestoreTab.activeQueryIsDocument,
+    firestoreTab.activeQueryPath,
+    firestoreTab.activeQueryRunId,
+    firestoreTab.errorMessage,
+    firestoreTab.isLoading,
+    firestoreTab.queryRows.length,
+    recordActivity,
+  ]);
+
+  useEffect(() => {
+    if (!activeTab || activeTab.kind !== 'auth-users' || !authTab.errorMessage) return;
+    const key = `${activeTab.id}:${authTab.authFilter}:${authTab.errorMessage}`;
+    if (loggedAuthFailures.current.has(key)) return;
+    loggedAuthFailures.current.add(key);
+    recordActivity({
+      action: authTab.authFilter.trim() ? 'Search users' : 'Load users',
+      area: 'auth',
+      error: { message: authTab.errorMessage },
+      metadata: { filter: authTab.authFilter.trim() || null },
+      status: 'failure',
+      summary: authTab.errorMessage,
+      target: { connectionId: activeTab.connectionId, type: 'auth-user' },
+    });
+  }, [activeTab, authTab.authFilter, authTab.errorMessage, recordActivity]);
+
+  useEffect(() => {
+    if (!activeTab || activeTab.kind !== 'js-query' || !jsTab.scriptRunId || !jsTab.scriptResult) {
+      return;
+    }
+    if (loggedScriptRuns.current.has(jsTab.scriptRunId)) return;
+    loggedScriptRuns.current.add(jsTab.scriptRunId);
+    const result = jsTab.scriptResult;
+    const status: ActivityLogStatus = result.cancelled
+      ? 'cancelled'
+      : result.errors.length > 0
+      ? 'failure'
+      : 'success';
+    recordActivity({
+      action: result.cancelled ? 'Cancel JavaScript query' : 'Run JavaScript query',
+      area: 'js-query',
+      ...(result.errors[0] ? { error: result.errors[0] } : {}),
+      durationMs: result.durationMs,
+      metadata: {
+        errorCount: result.errors.length,
+        logCount: result.logs.length,
+        outputCount: result.stream?.length ?? 0,
+      },
+      payload: { source: jsTab.scriptSource },
+      status,
+      summary: result.cancelled
+        ? 'JavaScript query cancelled'
+        : result.errors.length > 0
+        ? `JavaScript query failed with ${result.errors.length} error${
+          result.errors.length === 1 ? '' : 's'
+        }`
+        : 'JavaScript query completed',
+      target: { connectionId: activeTab.connectionId, type: 'script' },
+    });
+  }, [activeTab, jsTab.scriptResult, jsTab.scriptRunId, jsTab.scriptSource, recordActivity]);
+
   const tabModels = useMemo<ReadonlyArray<WorkspaceTabModel>>(
     () =>
       tabsState.tabs.map((tab) => ({
@@ -243,8 +413,7 @@ export function AppShell(
     {
       id: 'theme',
       label: 'Toggle theme',
-      onSelect: () =>
-        void appearance.setMode(appearance.resolvedTheme === 'dark' ? 'light' : 'dark'),
+      onSelect: () => handleThemeChange(appearance.resolvedTheme === 'dark' ? 'light' : 'dark'),
     },
     { id: 'focus-tree', label: 'Focus tree filter', onSelect: focusTreeFilter },
     { id: 'run-query', label: 'Run query', onSelect: handleRunQuery },
@@ -417,10 +586,35 @@ export function AppShell(
       confirmLabel: 'Remove',
       description: `Remove ${project?.name ?? 'this project'} from the workspace tree?`,
       onConfirm: () => {
-        void repositories.projects.remove(connectionId).then(() =>
-          queryClient.invalidateQueries({ queryKey: ['projects'] })
-        );
-        setLastAction(`Removed ${project?.name ?? 'project'}`);
+        const startedAt = Date.now();
+        void repositories.projects.remove(connectionId)
+          .then(async () => {
+            await queryClient.invalidateQueries({ queryKey: ['projects'] });
+            setLastAction(`Removed ${project?.name ?? 'project'}`);
+            recordActivity({
+              action: 'Remove account',
+              area: 'projects',
+              durationMs: elapsedMs(startedAt),
+              metadata: { connectionId, projectId: project?.projectId ?? null },
+              status: 'success',
+              summary: `Removed ${project?.name ?? 'project'}`,
+              target: projectTarget(project ?? null),
+            });
+          })
+          .catch((error) => {
+            const message = messageFromError(error, 'Could not remove project.');
+            setLastAction(`Remove failed: ${message}`);
+            recordActivity({
+              action: 'Remove account',
+              area: 'projects',
+              durationMs: elapsedMs(startedAt),
+              error: { message },
+              metadata: { connectionId, projectId: project?.projectId ?? null },
+              status: 'failure',
+              summary: message,
+              target: projectTarget(project ?? null),
+            });
+          });
       },
       title: 'Remove project',
     });
@@ -467,25 +661,126 @@ export function AppShell(
   }
 
   async function handleAddProject(input: ProjectAddInput): Promise<ProjectSummary> {
-    const project = await repositories.projects.add(input);
-    await queryClient.invalidateQueries({ queryKey: ['projects'] });
-    setLastAction(`Added ${project.name}`);
-    return project;
+    const startedAt = Date.now();
+    try {
+      const project = await repositories.projects.add(input);
+      await queryClient.invalidateQueries({ queryKey: ['projects'] });
+      setLastAction(`Added ${project.name}`);
+      recordActivity({
+        action: 'Add account',
+        area: 'projects',
+        durationMs: elapsedMs(startedAt),
+        metadata: {
+          name: project.name,
+          projectId: project.projectId,
+          target: project.target,
+        },
+        status: 'success',
+        summary: `Added ${project.name}`,
+        target: projectTarget(project),
+      });
+      return project;
+    } catch (error) {
+      const message = messageFromError(error, 'Could not add project.');
+      recordActivity({
+        action: 'Add account',
+        area: 'projects',
+        durationMs: elapsedMs(startedAt),
+        error: { message },
+        metadata: {
+          hasCredential: Boolean(input.credentialJson),
+          name: input.name,
+          projectId: input.projectId,
+          target: input.target,
+        },
+        status: 'failure',
+        summary: message,
+      });
+      throw error;
+    }
   }
 
   async function handleUpdateProject(
     id: string,
     patch: ProjectUpdatePatch,
   ): Promise<ProjectSummary> {
-    const project = await repositories.projects.update(id, patch);
-    await queryClient.invalidateQueries({ queryKey: ['projects'] });
-    setLastAction(`Updated ${project.name}`);
-    return project;
+    const startedAt = Date.now();
+    try {
+      const project = await repositories.projects.update(id, patch);
+      await queryClient.invalidateQueries({ queryKey: ['projects'] });
+      setLastAction(`Updated ${project.name}`);
+      recordActivity({
+        action: 'Update account',
+        area: 'projects',
+        durationMs: elapsedMs(startedAt),
+        metadata: {
+          changedKeys: Object.keys(patch).filter((key) => key !== 'credentialJson'),
+          projectId: project.projectId,
+          target: project.target,
+        },
+        status: 'success',
+        summary: `Updated ${project.name}`,
+        target: projectTarget(project),
+      });
+      return project;
+    } catch (error) {
+      const message = messageFromError(error, 'Could not update project.');
+      recordActivity({
+        action: 'Update account',
+        area: 'projects',
+        durationMs: elapsedMs(startedAt),
+        error: { message },
+        metadata: {
+          changedKeys: Object.keys(patch).filter((key) => key !== 'credentialJson'),
+          projectId: id,
+        },
+        status: 'failure',
+        summary: message,
+      });
+      throw error;
+    }
   }
 
   function handleRunQuery() {
     const path = firestoreTab.runQuery();
     if (path) setLastAction(`Ran query ${path}`);
+  }
+
+  function handleRefreshResults() {
+    const path = firestoreTab.refreshQuery();
+    if (path) setLastAction(`Refreshed results ${path}`);
+  }
+
+  function handleLoadMoreFirestore() {
+    const startedAt = Date.now();
+    firestoreTab.loadMore();
+    recordActivity({
+      action: 'Load more results',
+      area: 'firestore',
+      durationMs: elapsedMs(startedAt),
+      metadata: queryDraftMetadata(firestoreTab.activeDraft),
+      status: 'success',
+      summary: `Requested more results from ${firestoreTab.activeDraft.path}`,
+      target: {
+        connectionId: activeTab?.connectionId,
+        path: firestoreTab.activeDraft.path,
+        type: 'firestore-query',
+      },
+    });
+  }
+
+  function handleLoadMoreUsers() {
+    const startedAt = Date.now();
+    authTab.loadMore();
+    recordActivity({
+      action: 'Load more users',
+      area: 'auth',
+      durationMs: elapsedMs(startedAt),
+      metadata: { filter: authTab.authFilter.trim() || null },
+      status: 'success',
+      summary: 'Requested more Authentication users',
+      target: { connectionId: activeTab?.connectionId, type: 'auth-user' },
+    });
   }
 
   function handleRunScript() {
@@ -575,8 +870,8 @@ export function AppShell(
         onDeleteDocument={(path, options) => handleDeleteDocument(path, options)}
         onDraftChange={firestoreTab.setDraft}
         onGenerateDocumentId={handleGenerateDocumentId}
-        onLoadMore={firestoreTab.loadMore}
-        onLoadMoreUsers={authTab.loadMore}
+        onLoadMore={handleLoadMoreFirestore}
+        onLoadMoreUsers={handleLoadMoreUsers}
         onLoadSubcollections={handleLoadSubcollections}
         onOpenDocumentInNewTab={(path) => {
           const tabId = openFirestoreTabInNewTab(activeTab.connectionId, path);
@@ -588,11 +883,11 @@ export function AppShell(
           setLastAction(`Opened ${path} in new tab`);
         }}
         onReset={firestoreTab.resetDraft}
-        onRefreshResults={firestoreTab.refreshQuery}
+        onRefreshResults={handleRefreshResults}
         onRunQuery={handleRunQuery}
         onRunScript={handleRunScript}
         onSaveDocument={(path, data, options) => handleSaveDocument(path, data, options)}
-        onSaveUserCustomClaims={authTab.saveCustomClaims}
+        onSaveUserCustomClaims={handleSaveUserCustomClaims}
         onScriptChange={jsTab.setScriptSource}
         onSelectDocument={(path) => firestoreTab.selectDocument(activeTab.id, path)}
         onSelectUser={(uid) => selectionActions.selectAuthUser(uid)}
@@ -692,8 +987,20 @@ export function AppShell(
 
   function handleRefreshActiveTab() {
     if (!activeTab) return;
+    const startedAt = Date.now();
     if (activeTab.kind === 'firestore-query') handleRunQuery();
-    if (activeTab.kind === 'auth-users') authTab.refetch();
+    if (activeTab.kind === 'auth-users') {
+      authTab.refetch();
+      recordActivity({
+        action: 'Refresh users',
+        area: 'auth',
+        durationMs: elapsedMs(startedAt),
+        metadata: { filter: authTab.authFilter.trim() || null },
+        status: 'success',
+        summary: 'Requested Authentication refresh',
+        target: { connectionId: activeTab.connectionId, type: 'auth-user' },
+      });
+    }
     if (activeTab.kind === 'js-query') handleRunScript();
     setLastAction(`Refreshed ${activeTab.title}`);
   }
@@ -713,6 +1020,8 @@ export function AppShell(
     data: Record<string, unknown>,
   ) {
     if (!activeProject) return;
+    const startedAt = Date.now();
+    const documentPath = collectionPath ? `${collectionPath}/${documentId}` : documentId;
     try {
       const document = await repositories.firestore.createDocument(
         activeProject.id,
@@ -722,9 +1031,48 @@ export function AppShell(
       );
       if (dataMode !== 'mock') await queryClient.invalidateQueries({ queryKey: ['firestore'] });
       setLastAction(`Created ${document.path}`);
+      recordActivity({
+        action: 'Create document',
+        area: 'firestore',
+        durationMs: elapsedMs(startedAt),
+        metadata: {
+          collectionPath,
+          documentId,
+          ...documentDataMetadata(data),
+        },
+        payload: { data },
+        status: 'success',
+        summary: `Created ${document.path}`,
+        target: {
+          connectionId: activeProject.id,
+          path: document.path,
+          projectId: activeProject.projectId,
+          type: 'firestore-document',
+        },
+      });
     } catch (error) {
       const message = messageFromError(error, 'Could not create document.');
       setLastAction(`Create failed: ${message}`);
+      recordActivity({
+        action: 'Create document',
+        area: 'firestore',
+        durationMs: elapsedMs(startedAt),
+        error: { message },
+        metadata: {
+          collectionPath,
+          documentId,
+          ...documentDataMetadata(data),
+        },
+        payload: { data },
+        status: 'failure',
+        summary: message,
+        target: {
+          connectionId: activeProject.id,
+          path: documentPath,
+          projectId: activeProject.projectId,
+          type: 'firestore-document',
+        },
+      });
       throw error instanceof Error ? error : new Error(message);
     }
   }
@@ -735,6 +1083,7 @@ export function AppShell(
     options?: FirestoreSaveDocumentOptions,
   ): Promise<FirestoreSaveDocumentResult | void> {
     if (!activeProject) return;
+    const startedAt = Date.now();
     try {
       const result = await repositories.firestore.saveDocument(
         activeProject.id,
@@ -744,14 +1093,71 @@ export function AppShell(
       );
       if (result.status === 'conflict') {
         setLastAction(`Save conflict: ${documentPath}`);
+        recordActivity({
+          action: 'Save document',
+          area: 'firestore',
+          durationMs: elapsedMs(startedAt),
+          metadata: {
+            lastUpdateTime: options?.lastUpdateTime ?? null,
+            remoteUpdateTime: result.remoteDocument?.updateTime ?? null,
+            ...documentDataMetadata(data),
+          },
+          payload: { data },
+          status: 'conflict',
+          summary: `Save conflict on ${documentPath}`,
+          target: {
+            connectionId: activeProject.id,
+            path: documentPath,
+            projectId: activeProject.projectId,
+            type: 'firestore-document',
+          },
+        });
         return result;
       }
       if (dataMode !== 'mock') await queryClient.invalidateQueries({ queryKey: ['firestore'] });
       setLastAction(`Saved ${result.document.path}`);
+      recordActivity({
+        action: 'Save document',
+        area: 'firestore',
+        durationMs: elapsedMs(startedAt),
+        metadata: {
+          lastUpdateTime: options?.lastUpdateTime ?? null,
+          updateTime: result.document.updateTime ?? null,
+          ...documentDataMetadata(data),
+        },
+        payload: { data },
+        status: 'success',
+        summary: `Saved ${result.document.path}`,
+        target: {
+          connectionId: activeProject.id,
+          path: result.document.path,
+          projectId: activeProject.projectId,
+          type: 'firestore-document',
+        },
+      });
       return result;
     } catch (error) {
       const message = messageFromError(error, 'Could not save document.');
       setLastAction(`Save failed: ${message}`);
+      recordActivity({
+        action: 'Save document',
+        area: 'firestore',
+        durationMs: elapsedMs(startedAt),
+        error: { message },
+        metadata: {
+          lastUpdateTime: options?.lastUpdateTime ?? null,
+          ...documentDataMetadata(data),
+        },
+        payload: { data },
+        status: 'failure',
+        summary: message,
+        target: {
+          connectionId: activeProject.id,
+          path: documentPath,
+          projectId: activeProject.projectId,
+          type: 'firestore-document',
+        },
+      });
       throw error instanceof Error ? error : new Error(message);
     }
   }
@@ -761,6 +1167,7 @@ export function AppShell(
     options: DeleteDocumentOptions,
   ) {
     if (!activeProject || !activeTab) return;
+    const startedAt = Date.now();
     try {
       await repositories.firestore.deleteDocument(activeProject.id, documentPath, {
         deleteSubcollectionPaths: options.deleteSubcollectionPaths,
@@ -768,9 +1175,90 @@ export function AppShell(
       if (dataMode !== 'mock') await queryClient.invalidateQueries({ queryKey: ['firestore'] });
       firestoreTab.selectDocument(activeTab.id, null);
       setLastAction(`Deleted ${documentPath}`);
+      recordActivity({
+        action: 'Delete document',
+        area: 'firestore',
+        durationMs: elapsedMs(startedAt),
+        metadata: {
+          deleteSubcollectionPaths: options.deleteSubcollectionPaths,
+        },
+        status: 'success',
+        summary: `Deleted ${documentPath}`,
+        target: {
+          connectionId: activeProject.id,
+          path: documentPath,
+          projectId: activeProject.projectId,
+          type: 'firestore-document',
+        },
+      });
     } catch (error) {
       const message = messageFromError(error, 'Could not delete document.');
       setLastAction(`Delete failed: ${message}`);
+      recordActivity({
+        action: 'Delete document',
+        area: 'firestore',
+        durationMs: elapsedMs(startedAt),
+        error: { message },
+        metadata: {
+          deleteSubcollectionPaths: options.deleteSubcollectionPaths,
+        },
+        status: 'failure',
+        summary: message,
+        target: {
+          connectionId: activeProject.id,
+          path: documentPath,
+          projectId: activeProject.projectId,
+          type: 'firestore-document',
+        },
+      });
+      throw error instanceof Error ? error : new Error(message);
+    }
+  }
+
+  async function handleSaveUserCustomClaims(
+    uid: string,
+    claims: Record<string, unknown>,
+  ): Promise<void> {
+    if (!activeProject) {
+      await authTab.saveCustomClaims(uid, claims);
+      return;
+    }
+    const startedAt = Date.now();
+    try {
+      await authTab.saveCustomClaims(uid, claims);
+      recordActivity({
+        action: 'Save custom claims',
+        area: 'auth',
+        durationMs: elapsedMs(startedAt),
+        metadata: documentDataMetadata(claims),
+        payload: { claims },
+        status: 'success',
+        summary: `Saved custom claims for ${uid}`,
+        target: {
+          connectionId: activeProject.id,
+          projectId: activeProject.projectId,
+          type: 'auth-user',
+          uid,
+        },
+      });
+    } catch (error) {
+      const message = messageFromError(error, 'Could not save custom claims.');
+      recordActivity({
+        action: 'Save custom claims',
+        area: 'auth',
+        durationMs: elapsedMs(startedAt),
+        error: { message },
+        metadata: documentDataMetadata(claims),
+        payload: { claims },
+        status: 'failure',
+        summary: message,
+        target: {
+          connectionId: activeProject.id,
+          projectId: activeProject.projectId,
+          type: 'auth-user',
+          uid,
+        },
+      });
       throw error instanceof Error ? error : new Error(message);
     }
   }
@@ -789,6 +1277,106 @@ export function AppShell(
     setLastAction('Opened data location');
   }
 
+  function handleThemeChange(mode: AppearanceMode) {
+    const startedAt = Date.now();
+    void appearance.setMode(mode)
+      .then(() => {
+        recordActivity({
+          action: 'Change theme',
+          area: 'settings',
+          durationMs: elapsedMs(startedAt),
+          metadata: { mode },
+          status: 'success',
+          summary: `Theme changed to ${mode}`,
+          target: { type: 'settings' },
+        });
+      })
+      .catch((error) => {
+        const message = messageFromError(error, 'Could not change theme.');
+        setLastAction(`Theme failed: ${message}`);
+        recordActivity({
+          action: 'Change theme',
+          area: 'settings',
+          durationMs: elapsedMs(startedAt),
+          error: { message },
+          metadata: { mode },
+          status: 'failure',
+          summary: message,
+          target: { type: 'settings' },
+        });
+      });
+  }
+
+  function handleSettingsSaved(patch: SettingsPatch) {
+    recordActivity({
+      action: 'Update settings',
+      area: 'settings',
+      metadata: settingsPatchMetadata(patch),
+      status: 'success',
+      summary: settingsPatchSummary(patch),
+      target: { type: 'settings' },
+    });
+  }
+
+  function handleClearActivity() {
+    requestDestructiveAction({
+      confirmLabel: 'Clear',
+      description: 'Clear local Activity entries?',
+      onConfirm: () => {
+        void repositories.activity.clear()
+          .then(() => {
+            setActivityEntries([]);
+            setLatestActivityIssue(null);
+            setLastAction('Cleared activity');
+          })
+          .catch((error) => {
+            setLastAction(
+              `Activity clear failed: ${messageFromError(error, 'Could not clear activity.')}`,
+            );
+          });
+      },
+      title: 'Clear activity',
+    });
+  }
+
+  function handleExportActivity() {
+    void repositories.activity.export(activityListRequest)
+      .then((result) => {
+        if (!result.canceled) setLastAction(`Exported activity ${result.filePath ?? ''}`.trim());
+      })
+      .catch((error) => {
+        setLastAction(
+          `Activity export failed: ${messageFromError(error, 'Could not export activity.')}`,
+        );
+      });
+  }
+
+  function handleOpenActivityTarget(entry: ActivityLogEntry) {
+    const target = entry.target;
+    if (!target?.connectionId) return;
+    if (target.type === 'firestore-document' || target.type === 'firestore-query') {
+      const path = target.path ?? '';
+      if (!path) return;
+      const tabId = openFirestoreTab(target.connectionId, path);
+      tabActions.recordInteraction({
+        activeTabId: tabId,
+        path,
+        selectedTreeItemId: selection.treeItemId,
+      });
+      setLastAction(`Opened ${path}`);
+      return;
+    }
+    if (target.type === 'auth-user') {
+      const tabId = openToolTab('auth-users', target.connectionId);
+      selectionActions.selectAuthUser(target.uid ?? null);
+      tabActions.recordInteraction({
+        activeTabId: tabId,
+        selectedTreeItemId: selection.treeItemId,
+      });
+      setLastAction(target.uid ? `Opened ${target.uid}` : 'Opened Authentication');
+    }
+  }
+
   const desktopAppApi = getDesktopAppApi();
 
   return (
@@ -802,7 +1390,7 @@ export function AppShell(
         onAddProject={() => setAddProjectOpen(true)}
         onBack={handleBackInteraction}
         onForward={handleForwardInteraction}
-        onModeChange={(mode) => void appearance.setMode(mode)}
+        onModeChange={handleThemeChange}
         onOpenSettings={() => setSettingsOpen(true)}
       />
       <ResizablePanelGroup direction='horizontal' className='h-full min-h-0'>
@@ -850,7 +1438,7 @@ export function AppShell(
         </ResizablePanel>
         <ResizableHandle className='h-full w-px' />
         <ResizablePanel className='h-full' minSize={`${MIN_WORKSPACE_WIDTH}px`}>
-          <div className='grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto]'>
+          <div className='grid h-full min-h-0 grid-rows-[minmax(0,1fr)_auto_auto]'>
             <WorkspaceShell
               className='h-full min-h-0'
               tabStrip={
@@ -913,6 +1501,23 @@ export function AppShell(
                 {activeView}
               </RenderErrorBoundary>
             </WorkspaceShell>
+            <ActivityDrawer
+              area={activityArea}
+              entries={activityEntries}
+              expanded={activityExpanded}
+              isLoading={activityIsLoading}
+              open={activityOpen}
+              search={activitySearch}
+              status={activityStatus}
+              onAreaChange={setActivityArea}
+              onClear={handleClearActivity}
+              onClose={() => setActivityOpen(false)}
+              onExport={handleExportActivity}
+              onExpandedChange={setActivityExpanded}
+              onOpenTarget={handleOpenActivityTarget}
+              onSearchChange={setActivitySearch}
+              onStatusChange={setActivityStatus}
+            />
             <StatusBar
               left={
                 <>
@@ -923,7 +1528,27 @@ export function AppShell(
                   <span>{selection.treeItemId ?? 'No tree selection'}</span>
                 </>
               }
-              right={<span>{lastAction}</span>}
+              right={
+                <>
+                  <Button
+                    aria-pressed={activityOpen}
+                    size='xs'
+                    variant={activityButtonVariant(latestActivityIssue)}
+                    onClick={() => setActivityOpen((current) => !current)}
+                  >
+                    <ListChecks size={13} aria-hidden='true' />
+                    Activity
+                    {latestActivityIssue
+                      ? (
+                        <Badge variant={activityIssueBadgeVariant(latestActivityIssue.status)}>
+                          {latestActivityIssue.status}
+                        </Badge>
+                      )
+                      : null}
+                  </Button>
+                  <span>{lastAction}</span>
+                </>
+              }
             />
           </div>
         </ResizablePanel>
@@ -936,6 +1561,7 @@ export function AppShell(
         open={settingsOpen}
         onDensityChange={setDensity}
         onOpenChange={setSettingsOpen}
+        onSettingsSaved={handleSettingsSaved}
       />
       <DestructiveActionDialog
         action={pendingDestructiveAction}
@@ -1313,4 +1939,112 @@ function persistSidebarWidth(repositories: RepositorySet, size: number) {
 function messageFromError(error: unknown, fallback: string): string {
   if (error instanceof Error) return error.message;
   return fallback;
+}
+
+function isActivityIssue(entry: ActivityLogEntry): boolean {
+  return entry.status === 'failure' || entry.status === 'conflict';
+}
+
+function activityEntryMatchesRequest(
+  entry: ActivityLogEntry,
+  request: ActivityLogListRequest,
+): boolean {
+  if (request.area && request.area !== 'all' && entry.area !== request.area) return false;
+  if (request.status && request.status !== 'all' && entry.status !== request.status) return false;
+  const search = request.search?.trim().toLowerCase();
+  if (!search) return true;
+  return [
+    entry.action,
+    entry.area,
+    entry.status,
+    entry.summary,
+    entry.target?.label,
+    entry.target?.path,
+    entry.target?.uid,
+    entry.error?.message,
+  ].some((value) => value?.toLowerCase().includes(search));
+}
+
+function activityButtonVariant(
+  entry: ActivityLogEntry | null,
+): 'danger' | 'secondary' | 'warning' {
+  if (entry?.status === 'failure') return 'danger';
+  if (entry?.status === 'conflict') return 'warning';
+  return 'secondary';
+}
+
+function activityIssueBadgeVariant(status: ActivityLogStatus): 'danger' | 'neutral' | 'warning' {
+  if (status === 'failure') return 'danger';
+  if (status === 'conflict') return 'warning';
+  return 'neutral';
+}
+
+function elapsedMs(startedAt: number): number {
+  return Math.max(0, Date.now() - startedAt);
+}
+
+function queryDraftMetadata(draft: FirestoreQueryDraft): Record<string, unknown> {
+  return {
+    filters: (draft.filters ?? []).map((filter) => ({
+      field: filter.field,
+      op: filter.op,
+      valueType: valueKind(filter.value),
+    })),
+    limit: draft.limit,
+    path: draft.path,
+    sort: draft.sortField
+      ? { direction: draft.sortDirection, field: draft.sortField }
+      : null,
+  };
+}
+
+function documentDataMetadata(data: Record<string, unknown>): Record<string, unknown> {
+  return {
+    fieldCount: Object.keys(data).length,
+    fields: Object.fromEntries(
+      Object.entries(data).map(([field, value]) => [field, valueKind(value)]),
+    ),
+  };
+}
+
+function valueKind(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  if (typeof value === 'object') {
+    const type = (value as { readonly __type__?: unknown; }).__type__;
+    return typeof type === 'string' ? type : 'map';
+  }
+  return typeof value;
+}
+
+function projectTarget(project: ProjectSummary | null): ActivityLogEntry['target'] {
+  if (!project) return undefined;
+  return {
+    connectionId: project.id,
+    label: project.name,
+    projectId: project.projectId,
+    type: 'project',
+  };
+}
+
+function settingsPatchMetadata(patch: SettingsPatch): Record<string, unknown> {
+  return {
+    changedKeys: Object.keys(patch),
+    ...(patch.dataMode ? { dataMode: patch.dataMode } : {}),
+    ...(patch.activityLog
+      ? {
+        activityLog: {
+          detailMode: patch.activityLog.detailMode,
+          enabled: patch.activityLog.enabled,
+          maxBytes: patch.activityLog.maxBytes,
+        },
+      }
+      : {}),
+  };
+}
+
+function settingsPatchSummary(patch: SettingsPatch): string {
+  if (patch.dataMode) return `Data mode changed to ${patch.dataMode}`;
+  if (patch.activityLog) return 'Activity settings changed';
+  return 'Settings changed';
 }

--- a/apps/desktop/src/renderer/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/app/AppShell.tsx
@@ -220,7 +220,6 @@ export function AppShell(
     try {
       const entries = await repositories.activity.list(activityListRequest);
       setActivityEntries(entries);
-      setLatestActivityIssue(entries.find(isActivityIssue) ?? null);
     } catch (error) {
       setLastAction(`Activity load failed: ${messageFromError(error, 'Could not load activity.')}`);
     } finally {
@@ -231,7 +230,7 @@ export function AppShell(
   const recordActivity = useCallback((input: ActivityLogAppendInput) => {
     void repositories.activity.append(input)
       .then((entry) => {
-        if (isActivityIssue(entry)) setLatestActivityIssue(entry);
+        if (isActivityIssue(entry) && !activityOpenRef.current) setLatestActivityIssue(entry);
         setActivityEntries((current) =>
           activityOpenRef.current
             && activityEntryMatchesRequest(entry, activityListRequestRef.current)
@@ -248,6 +247,7 @@ export function AppShell(
 
   useEffect(() => {
     activityOpenRef.current = activityOpen;
+    if (activityOpen) setLatestActivityIssue(null);
   }, [activityOpen]);
 
   useEffect(() => {
@@ -255,8 +255,8 @@ export function AppShell(
   }, [activityListRequest]);
 
   useEffect(() => {
-    void repositories.activity.list({ limit: 50 })
-      .then((entries) => setLatestActivityIssue(entries.find(isActivityIssue) ?? null))
+    void repositories.activity.list({ limit: 1 })
+      .then((entries) => setLatestActivityIssue(activityIssueFromLatestEntry(entries)))
       .catch(() => {});
   }, [repositories.activity]);
 
@@ -2053,6 +2053,13 @@ function messageFromError(error: unknown, fallback: string): string {
 
 function isActivityIssue(entry: ActivityLogEntry): boolean {
   return entry.status === 'failure' || entry.status === 'conflict';
+}
+
+function activityIssueFromLatestEntry(
+  entries: ReadonlyArray<ActivityLogEntry>,
+): ActivityLogEntry | null {
+  const latest = entries[0];
+  return latest && isActivityIssue(latest) ? latest : null;
 }
 
 function activityEntryMatchesRequest(

--- a/apps/desktop/src/renderer/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/app/AppShell.tsx
@@ -113,6 +113,8 @@ interface DestructiveAction {
   readonly title: string;
 }
 
+const MAX_ACTIVITY_DEDUPE_KEYS = 500;
+
 interface PendingCreateDocumentRequest extends FirestoreCreateDocumentRequest {
   readonly tabId: string;
 }
@@ -299,8 +301,7 @@ export function AppShell(
     if (!runId || !path || firestoreTab.isLoading) return;
 
     const key = `${activeTab.id}:${runId}`;
-    if (loggedFirestoreRuns.current.has(key)) return;
-    loggedFirestoreRuns.current.add(key);
+    if (!rememberActivityKey(loggedFirestoreRuns.current, key)) return;
 
     const isDocument = firestoreTab.activeQueryIsDocument;
     const errorMessage = firestoreTab.errorMessage;
@@ -342,8 +343,7 @@ export function AppShell(
   useEffect(() => {
     if (!activeTab || activeTab.kind !== 'auth-users' || !authTab.errorMessage) return;
     const key = `${activeTab.id}:${authTab.authFilter}:${authTab.errorMessage}`;
-    if (loggedAuthFailures.current.has(key)) return;
-    loggedAuthFailures.current.add(key);
+    if (!rememberActivityKey(loggedAuthFailures.current, key)) return;
     recordActivity({
       action: authTab.authFilter.trim() ? 'Search users' : 'Load users',
       area: 'auth',
@@ -359,8 +359,7 @@ export function AppShell(
     if (!activeTab || activeTab.kind !== 'js-query' || !jsTab.scriptRunId || !jsTab.scriptResult) {
       return;
     }
-    if (loggedScriptRuns.current.has(jsTab.scriptRunId)) return;
-    loggedScriptRuns.current.add(jsTab.scriptRunId);
+    if (!rememberActivityKey(loggedScriptRuns.current, jsTab.scriptRunId)) return;
     const result = jsTab.scriptResult;
     const status: ActivityLogStatus = result.cancelled
       ? 'cancelled'
@@ -2088,6 +2087,17 @@ function activityIssueBadgeVariant(status: ActivityLogStatus): 'danger' | 'neutr
   if (status === 'failure') return 'danger';
   if (status === 'conflict') return 'warning';
   return 'neutral';
+}
+
+function rememberActivityKey(keys: Set<string>, key: string): boolean {
+  if (keys.has(key)) return false;
+  keys.add(key);
+  while (keys.size > MAX_ACTIVITY_DEDUPE_KEYS) {
+    const oldestKey = keys.keys().next().value as string | undefined;
+    if (!oldestKey) break;
+    keys.delete(oldestKey);
+  }
+  return true;
 }
 
 function elapsedMs(startedAt: number): number {

--- a/apps/desktop/src/renderer/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/app/AppShell.tsx
@@ -28,8 +28,11 @@ import type {
   AuthUser,
   FirestoreCollectionNode,
   FirestoreDocumentResult,
+  FirestoreFieldPatchOperation,
   FirestoreSaveDocumentOptions,
   FirestoreSaveDocumentResult,
+  FirestoreUpdateDocumentFieldsOptions,
+  FirestoreUpdateDocumentFieldsResult,
   ProjectAddInput,
   ProjectSummary,
   ProjectUpdatePatch,
@@ -887,6 +890,8 @@ export function AppShell(
         onRunQuery={handleRunQuery}
         onRunScript={handleRunScript}
         onSaveDocument={(path, data, options) => handleSaveDocument(path, data, options)}
+        onUpdateDocumentFields={(path, operations, options) =>
+          handleUpdateDocumentFields(path, operations, options)}
         onSaveUserCustomClaims={handleSaveUserCustomClaims}
         onScriptChange={jsTab.setScriptSource}
         onSelectDocument={(path) => firestoreTab.selectDocument(activeTab.id, path)}
@@ -1149,6 +1154,103 @@ export function AppShell(
           ...documentDataMetadata(data),
         },
         payload: { data },
+        status: 'failure',
+        summary: message,
+        target: {
+          connectionId: activeProject.id,
+          path: documentPath,
+          projectId: activeProject.projectId,
+          type: 'firestore-document',
+        },
+      });
+      throw error instanceof Error ? error : new Error(message);
+    }
+  }
+
+  async function handleUpdateDocumentFields(
+    documentPath: string,
+    operations: ReadonlyArray<FirestoreFieldPatchOperation>,
+    options: FirestoreUpdateDocumentFieldsOptions,
+  ): Promise<FirestoreUpdateDocumentFieldsResult | void> {
+    if (!activeProject) return;
+    const startedAt = Date.now();
+    try {
+      const result = await repositories.firestore.updateDocumentFields(
+        activeProject.id,
+        documentPath,
+        operations,
+        options,
+      );
+      if (result.status === 'conflict' || result.status === 'document-changed') {
+        const status = result.status === 'conflict' ? 'conflict' : 'success';
+        setLastAction(`${fieldPatchStatusLabel(result.status)}: ${documentPath}`);
+        recordActivity({
+          action: 'Update fields',
+          area: 'firestore',
+          durationMs: elapsedMs(startedAt),
+          metadata: {
+            classification: result.status,
+            lastUpdateTime: options.lastUpdateTime ?? null,
+            remoteUpdateTime: result.remoteDocument?.updateTime ?? null,
+            staleBehavior: options.staleBehavior,
+            ...fieldPatchMetadata(operations),
+          },
+          payload: { operations },
+          status,
+          summary: `${fieldPatchStatusLabel(result.status)} on ${documentPath}`,
+          target: {
+            connectionId: activeProject.id,
+            path: documentPath,
+            projectId: activeProject.projectId,
+            type: 'firestore-document',
+          },
+        });
+        return result;
+      }
+      if (dataMode !== 'mock') await queryClient.invalidateQueries({ queryKey: ['firestore'] });
+      setLastAction(
+        result.documentChanged
+          ? `Saved ${result.document.path}; document changed elsewhere`
+          : `Saved ${result.document.path}`,
+      );
+      recordActivity({
+        action: 'Update fields',
+        area: 'firestore',
+        durationMs: elapsedMs(startedAt),
+        metadata: {
+          classification: result.documentChanged ? 'document-changed-saved' : 'saved',
+          lastUpdateTime: options.lastUpdateTime ?? null,
+          staleBehavior: options.staleBehavior,
+          updateTime: result.document.updateTime ?? null,
+          ...fieldPatchMetadata(operations),
+        },
+        payload: { operations },
+        status: 'success',
+        summary: result.documentChanged
+          ? `Saved ${result.document.path}; document changed elsewhere`
+          : `Saved ${result.document.path}`,
+        target: {
+          connectionId: activeProject.id,
+          path: result.document.path,
+          projectId: activeProject.projectId,
+          type: 'firestore-document',
+        },
+      });
+      return result;
+    } catch (error) {
+      const message = messageFromError(error, 'Could not update fields.');
+      setLastAction(`Field update failed: ${message}`);
+      recordActivity({
+        action: 'Update fields',
+        area: 'firestore',
+        durationMs: elapsedMs(startedAt),
+        error: { message },
+        metadata: {
+          lastUpdateTime: options.lastUpdateTime ?? null,
+          staleBehavior: options.staleBehavior,
+          ...fieldPatchMetadata(operations),
+        },
+        payload: { operations },
         status: 'failure',
         summary: message,
         target: {
@@ -1839,6 +1941,14 @@ interface TabViewProps {
     data: Record<string, unknown>,
     options?: FirestoreSaveDocumentOptions,
   ) => Promise<FirestoreSaveDocumentResult | void> | FirestoreSaveDocumentResult | void;
+  readonly onUpdateDocumentFields: (
+    documentPath: string,
+    operations: ReadonlyArray<FirestoreFieldPatchOperation>,
+    options: FirestoreUpdateDocumentFieldsOptions,
+  ) =>
+    | Promise<FirestoreUpdateDocumentFieldsResult | void>
+    | FirestoreUpdateDocumentFieldsResult
+    | void;
   readonly onSaveUserCustomClaims: (
     uid: string,
     claims: Record<string, unknown>,
@@ -1921,6 +2031,7 @@ function TabView(props: TabViewProps) {
       onRefreshResults={props.onRefreshResults}
       onRun={props.onRunQuery}
       onSaveDocument={props.onSaveDocument}
+      onUpdateDocumentFields={props.onUpdateDocumentFields}
       onSelectDocument={props.onSelectDocument}
     />
   );
@@ -2007,6 +2118,26 @@ function documentDataMetadata(data: Record<string, unknown>): Record<string, unk
   };
 }
 
+function fieldPatchMetadata(
+  operations: ReadonlyArray<FirestoreFieldPatchOperation>,
+): Record<string, unknown> {
+  return {
+    operationCount: operations.length,
+    operations: operations.map((operation) => ({
+      fieldPath: operation.fieldPath,
+      type: operation.type,
+      ...(operation.type === 'set' ? { valueType: valueKind(operation.value) } : {}),
+    })),
+    writeMode: 'field-patch',
+  };
+}
+
+function fieldPatchStatusLabel(
+  status: 'conflict' | 'document-changed',
+): string {
+  return status === 'conflict' ? 'Field conflict' : 'Document changed elsewhere';
+}
+
 function valueKind(value: unknown): string {
   if (value === null) return 'null';
   if (Array.isArray(value)) return 'array';
@@ -2040,11 +2171,19 @@ function settingsPatchMetadata(patch: SettingsPatch): Record<string, unknown> {
         },
       }
       : {}),
+    ...(patch.firestoreWrites
+      ? {
+        firestoreWrites: {
+          fieldStaleBehavior: patch.firestoreWrites.fieldStaleBehavior,
+        },
+      }
+      : {}),
   };
 }
 
 function settingsPatchSummary(patch: SettingsPatch): string {
   if (patch.dataMode) return `Data mode changed to ${patch.dataMode}`;
   if (patch.activityLog) return 'Activity settings changed';
+  if (patch.firestoreWrites) return 'Firestore write settings changed';
   return 'Settings changed';
 }

--- a/apps/desktop/src/renderer/app/RepositoryProvider.test.tsx
+++ b/apps/desktop/src/renderer/app/RepositoryProvider.test.tsx
@@ -1,5 +1,6 @@
 import {
   DEFAULT_ACTIVITY_LOG_SETTINGS,
+  DEFAULT_FIRESTORE_WRITE_SETTINGS,
   type SettingsSnapshot,
 } from '@firebase-desk/repo-contracts';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -14,6 +15,7 @@ const snapshot: SettingsSnapshot = {
   hotkeyOverrides: {},
   resultTableLayouts: {},
   firestoreFieldCatalogs: {},
+  firestoreWrites: DEFAULT_FIRESTORE_WRITE_SETTINGS,
 };
 
 afterEach(() => {

--- a/apps/desktop/src/renderer/app/RepositoryProvider.test.tsx
+++ b/apps/desktop/src/renderer/app/RepositoryProvider.test.tsx
@@ -1,8 +1,12 @@
-import type { SettingsSnapshot } from '@firebase-desk/repo-contracts';
+import {
+  DEFAULT_ACTIVITY_LOG_SETTINGS,
+  type SettingsSnapshot,
+} from '@firebase-desk/repo-contracts';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createRepositories } from './RepositoryProvider.tsx';
 
 const snapshot: SettingsSnapshot = {
+  activityLog: DEFAULT_ACTIVITY_LOG_SETTINGS,
   sidebarWidth: 320,
   inspectorWidth: 360,
   theme: 'system',
@@ -37,6 +41,32 @@ describe('createRepositories', () => {
 
     expect(save).toHaveBeenCalledWith({ dataMode: 'live' });
     expect(onDataModeChange).toHaveBeenCalledWith('live');
+  });
+
+  it('uses desktop activity in mock data mode when the desktop API is available', async () => {
+    const listActivity = vi.fn(async () => []);
+    vi.stubGlobal('firebaseDesk', {
+      activity: {
+        append: vi.fn(),
+        clear: vi.fn(),
+        export: vi.fn(),
+        list: listActivity,
+      },
+      projects: {
+        list: vi.fn(async () => []),
+      },
+      settings: {
+        load: vi.fn(async () => snapshot),
+        save: vi.fn(async () => snapshot),
+        getHotkeyOverrides: vi.fn(async () => ({})),
+        setHotkeyOverrides: vi.fn(async () => {}),
+      },
+    });
+
+    const repositories = createRepositories({ dataMode: 'mock' });
+    await repositories.activity.list({ limit: 1 });
+
+    expect(listActivity).toHaveBeenCalledWith({ limit: 1 });
   });
 
   it('does not fall back to mock feature repositories in live data mode', async () => {

--- a/apps/desktop/src/renderer/app/RepositoryProvider.tsx
+++ b/apps/desktop/src/renderer/app/RepositoryProvider.tsx
@@ -1,4 +1,5 @@
 import type {
+  ActivityLogRepository,
   AuthRepository,
   DataMode,
   FirestoreRepository,
@@ -10,6 +11,7 @@ import type {
   SettingsSnapshot,
 } from '@firebase-desk/repo-contracts';
 import {
+  MockActivityLogRepository,
   MockAuthRepository,
   MockFirestoreRepository,
   MockProjectsRepository,
@@ -17,6 +19,7 @@ import {
   MockSettingsRepository,
 } from '@firebase-desk/repo-mocks';
 import { createContext, type ReactNode, useContext } from 'react';
+import { IpcActivityLogRepository } from './repositories/ipc-activity-log-repository.ts';
 import { IpcAuthRepository } from './repositories/ipc-auth-repository.ts';
 import { IpcFirestoreRepository } from './repositories/ipc-firestore-repository.ts';
 import { IpcProjectsRepository } from './repositories/ipc-projects-repository.ts';
@@ -24,6 +27,7 @@ import { IpcScriptRunnerRepository } from './repositories/ipc-script-runner-repo
 import { IpcSettingsRepository } from './repositories/ipc-settings-repository.ts';
 
 export interface RepositorySet {
+  readonly activity: ActivityLogRepository;
   readonly auth: AuthRepository;
   readonly firestore: FirestoreRepository;
   readonly projects: ProjectsRepository;
@@ -45,6 +49,7 @@ export interface CreateRepositoriesOptions {
 
 export function createMockRepositories(): RepositorySet {
   return {
+    activity: new MockActivityLogRepository(),
     auth: new MockAuthRepository(),
     firestore: new MockFirestoreRepository(),
     projects: new MockProjectsRepository(),
@@ -58,15 +63,19 @@ export function createRepositories(
 ): RepositorySet {
   const desktopApiAvailable = hasDesktopApi();
   const settings = desktopApiAvailable ? new IpcSettingsRepository() : new MockSettingsRepository();
+  const activity = desktopApiAvailable
+    ? new IpcActivityLogRepository()
+    : new MockActivityLogRepository();
   const repositories: RepositorySet = dataMode === 'live'
     ? {
+      activity,
       auth: new IpcAuthRepository(),
       firestore: new IpcFirestoreRepository(),
       projects: new IpcProjectsRepository(),
       scriptRunner: new IpcScriptRunnerRepository(),
       settings,
     }
-    : { ...createMockRepositories(), settings };
+    : { ...createMockRepositories(), activity, settings };
 
   return {
     ...repositories,

--- a/apps/desktop/src/renderer/app/hooks/useFirestoreTabState.ts
+++ b/apps/desktop/src/renderer/app/hooks/useFirestoreTabState.ts
@@ -30,8 +30,12 @@ interface UseFirestoreTabStateInput {
 }
 
 export interface FirestoreTabState {
+  readonly activeLoadedPageCount: number;
   readonly drafts: Readonly<Record<string, FirestoreQueryDraft>>;
   readonly activeDraft: FirestoreQueryDraft;
+  readonly activeQueryIsDocument: boolean;
+  readonly activeQueryPath: string | null;
+  readonly activeQueryRunId: number | null;
   readonly errorMessage: string | null;
   readonly hasMore: boolean;
   readonly isFetchingMore: boolean;
@@ -205,8 +209,14 @@ export function useFirestoreTabState(
   }
 
   return {
+    activeLoadedPageCount: queryRequestIsDocument
+      ? (queryDocumentResult.data ? 1 : 0)
+      : loadedPageCount,
     drafts,
     activeDraft,
+    activeQueryIsDocument: queryRequestIsDocument,
+    activeQueryPath: submittedQuery?.path ?? null,
+    activeQueryRunId: activeQueryRequest?.runId ?? null,
     errorMessage,
     hasMore: !queryRequestIsDocument && Boolean(queryResult.hasNextPage),
     isFetchingMore: !queryRequestIsDocument && queryResult.isFetchingNextPage,

--- a/apps/desktop/src/renderer/app/repositories/ipc-activity-log-repository.ts
+++ b/apps/desktop/src/renderer/app/repositories/ipc-activity-log-repository.ts
@@ -1,0 +1,37 @@
+import type { IpcRequest } from '@firebase-desk/ipc-schemas';
+import type {
+  ActivityLogAppendInput,
+  ActivityLogEntry,
+  ActivityLogExportResult,
+  ActivityLogListRequest,
+  ActivityLogRepository,
+} from '@firebase-desk/repo-contracts';
+
+export class IpcActivityLogRepository implements ActivityLogRepository {
+  async append(input: ActivityLogAppendInput): Promise<ActivityLogEntry> {
+    return await window.firebaseDesk.activity.append(input);
+  }
+
+  async clear(): Promise<void> {
+    await window.firebaseDesk.activity.clear();
+  }
+
+  async export(request?: ActivityLogListRequest): Promise<ActivityLogExportResult> {
+    return await window.firebaseDesk.activity.export(toIpcListRequest(request));
+  }
+
+  async list(request?: ActivityLogListRequest): Promise<ReadonlyArray<ActivityLogEntry>> {
+    return await window.firebaseDesk.activity.list(toIpcListRequest(request));
+  }
+}
+
+function toIpcListRequest(
+  request?: ActivityLogListRequest,
+): IpcRequest<'activity.list'> {
+  return {
+    ...(request?.area === undefined ? {} : { area: request.area }),
+    ...(request?.limit === undefined ? {} : { limit: request.limit }),
+    ...(request?.search === undefined ? {} : { search: request.search }),
+    ...(request?.status === undefined ? {} : { status: request.status }),
+  };
+}

--- a/apps/desktop/src/renderer/app/repositories/ipc-firestore-repository.test.ts
+++ b/apps/desktop/src/renderer/app/repositories/ipc-firestore-repository.test.ts
@@ -49,6 +49,17 @@ describe('IpcFirestoreRepository', () => {
           updateTime: '2026-04-29T00:00:01.000Z',
         },
       }),
+      updateDocumentFields: vi.fn().mockResolvedValue({
+        status: 'saved',
+        document: {
+          id: 'ord_2',
+          path: 'orders/ord_2',
+          data: { status: 'shipped' },
+          hasSubcollections: false,
+          updateTime: '2026-04-29T00:00:02.000Z',
+        },
+        documentChanged: true,
+      }),
       deleteDocument: vi.fn().mockResolvedValue(undefined),
     } satisfies Partial<DesktopFirestoreApi>;
     Object.defineProperty(window, 'firebaseDesk', {
@@ -116,6 +127,25 @@ describe('IpcFirestoreRepository', () => {
         updateTime: '2026-04-29T00:00:01.000Z',
       },
     });
+    await expect(repository.updateDocumentFields('emu', 'orders/ord_2', [{
+      baseValue: 'draft',
+      fieldPath: ['status'],
+      type: 'set',
+      value: 'shipped',
+    }], {
+      lastUpdateTime: '2026-04-29T00:00:01.000Z',
+      staleBehavior: 'save-and-notify',
+    })).resolves.toEqual({
+      status: 'saved',
+      document: {
+        id: 'ord_2',
+        path: 'orders/ord_2',
+        data: { status: 'shipped' },
+        hasSubcollections: false,
+        updateTime: '2026-04-29T00:00:02.000Z',
+      },
+      documentChanged: true,
+    });
     await expect(repository.deleteDocument('emu', 'orders/ord_2', {
       deleteSubcollectionPaths: ['orders/ord_2/events'],
     })).resolves.toBeUndefined();
@@ -147,6 +177,20 @@ describe('IpcFirestoreRepository', () => {
       documentPath: 'orders/ord_2',
       data: { status: 'draft' },
       options: { lastUpdateTime: '2026-04-29T00:00:00.000Z' },
+    });
+    expect(firestore.updateDocumentFields).toHaveBeenCalledWith({
+      connectionId: 'emu',
+      documentPath: 'orders/ord_2',
+      operations: [{
+        baseValue: 'draft',
+        fieldPath: ['status'],
+        type: 'set',
+        value: 'shipped',
+      }],
+      options: {
+        lastUpdateTime: '2026-04-29T00:00:01.000Z',
+        staleBehavior: 'save-and-notify',
+      },
     });
     expect(firestore.deleteDocument).toHaveBeenCalledWith({
       connectionId: 'emu',

--- a/apps/desktop/src/renderer/app/repositories/ipc-firestore-repository.ts
+++ b/apps/desktop/src/renderer/app/repositories/ipc-firestore-repository.ts
@@ -4,11 +4,14 @@ import type {
   FirestoreDeleteDocumentOptions,
   FirestoreDocumentNode,
   FirestoreDocumentResult,
+  FirestoreFieldPatchOperation,
   FirestoreGeneratedDocumentId,
   FirestoreQuery,
   FirestoreRepository,
   FirestoreSaveDocumentOptions,
   FirestoreSaveDocumentResult,
+  FirestoreUpdateDocumentFieldsOptions,
+  FirestoreUpdateDocumentFieldsResult,
   Page,
   PageRequest,
 } from '@firebase-desk/repo-contracts';
@@ -95,6 +98,31 @@ export class IpcFirestoreRepository implements FirestoreRepository {
       : { status: 'saved', document: toDocumentResult(result.document) };
   }
 
+  async updateDocumentFields(
+    connectionId: string,
+    documentPath: string,
+    operations: ReadonlyArray<FirestoreFieldPatchOperation>,
+    options: FirestoreUpdateDocumentFieldsOptions,
+  ): Promise<FirestoreUpdateDocumentFieldsResult> {
+    const result = await window.firebaseDesk.firestore.updateDocumentFields({
+      connectionId,
+      documentPath,
+      operations: operations.map(toIpcFieldPatchOperation),
+      options: toIpcUpdateFieldsOptions(options),
+    });
+    if (result.status === 'conflict' || result.status === 'document-changed') {
+      return {
+        status: result.status,
+        remoteDocument: result.remoteDocument ? toDocumentResult(result.remoteDocument) : null,
+      };
+    }
+    return {
+      status: 'saved',
+      document: toDocumentResult(result.document),
+      ...(result.documentChanged ? { documentChanged: true } : {}),
+    };
+  }
+
   async generateDocumentId(
     connectionId: string,
     collectionPath: string,
@@ -164,6 +192,32 @@ function toIpcSaveOptions(
   options: FirestoreSaveDocumentOptions,
 ): NonNullable<IpcRequest<'firestore.saveDocument'>['options']> {
   return options.lastUpdateTime ? { lastUpdateTime: options.lastUpdateTime } : {};
+}
+
+function toIpcUpdateFieldsOptions(
+  options: FirestoreUpdateDocumentFieldsOptions,
+): IpcRequest<'firestore.updateDocumentFields'>['options'] {
+  return {
+    staleBehavior: options.staleBehavior,
+    ...(options.lastUpdateTime ? { lastUpdateTime: options.lastUpdateTime } : {}),
+  };
+}
+
+function toIpcFieldPatchOperation(
+  operation: FirestoreFieldPatchOperation,
+): IpcRequest<'firestore.updateDocumentFields'>['operations'][number] {
+  return operation.type === 'delete'
+    ? {
+      baseValue: operation.baseValue,
+      fieldPath: [...operation.fieldPath],
+      type: 'delete',
+    }
+    : {
+      baseValue: operation.baseValue,
+      fieldPath: [...operation.fieldPath],
+      type: 'set',
+      value: operation.value,
+    };
 }
 
 function toCollectionNode(

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -13,6 +13,19 @@ declare global {
     readonly check: (request: IpcRequest<'health.check'>) => Promise<IpcResponse<'health.check'>>;
   }
 
+  interface DesktopActivityApi {
+    readonly append: (
+      request: IpcRequest<'activity.append'>,
+    ) => Promise<IpcResponse<'activity.append'>>;
+    readonly clear: () => Promise<IpcResponse<'activity.clear'>>;
+    readonly export: (
+      request: IpcRequest<'activity.export'>,
+    ) => Promise<IpcResponse<'activity.export'>>;
+    readonly list: (
+      request: IpcRequest<'activity.list'>,
+    ) => Promise<IpcResponse<'activity.list'>>;
+  }
+
   interface DesktopProjectsApi {
     readonly list: () => Promise<IpcResponse<'projects.list'>>;
     readonly get: (request: IpcRequest<'projects.get'>) => Promise<IpcResponse<'projects.get'>>;
@@ -95,6 +108,7 @@ declare global {
 
   interface DesktopApi {
     readonly app: DesktopAppApi;
+    readonly activity: DesktopActivityApi;
     readonly health: DesktopHealthApi;
     readonly projects: DesktopProjectsApi;
     readonly settings: DesktopSettingsApi;

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -76,6 +76,9 @@ declare global {
     readonly saveDocument: (
       request: IpcRequest<'firestore.saveDocument'>,
     ) => Promise<IpcResponse<'firestore.saveDocument'>>;
+    readonly updateDocumentFields: (
+      request: IpcRequest<'firestore.updateDocumentFields'>,
+    ) => Promise<IpcResponse<'firestore.updateDocumentFields'>>;
     readonly deleteDocument: (
       request: IpcRequest<'firestore.deleteDocument'>,
     ) => Promise<IpcResponse<'firestore.deleteDocument'>>;

--- a/docs/testing-ci.md
+++ b/docs/testing-ci.md
@@ -47,6 +47,14 @@
 - `pnpm package:linux:docker` for local Docker reproduction of the Linux release package smoke. The wrapper uses `linux/amd64` and the Docker capability required by Chromium's sandbox.
 - `pnpm dev` (parallel: desktop + wireframe)
 
+### Desktop Packaging Dependencies
+
+- Workspace packages in `apps/desktop/package.json` must be listed in `apps/desktop/src/main/packaging/main-externalize-deps.ts`.
+- `@firebase-desk/*` packages export TypeScript source for development. Packaged Electron must bundle them into main/preload/renderer output and must not load them from `node_modules`.
+- `apps/desktop/electron-builder.yml` excludes `node_modules/@firebase-desk/**` from `app.asar`; do not rely on workspace package files being present at runtime.
+- Main-process third-party runtime deps must be direct `apps/desktop` dependencies. Add them to `mainExternalizeDeps.include` only when they should stay external, like `firebase-admin`.
+- `apps/desktop/src/main/packaging/electron-vite-config.test.ts` guards new desktop workspace deps.
+
 ### Policy
 
 - Workflows are added before live wireframe UI work.

--- a/e2e/fixtures/live-app.ts
+++ b/e2e/fixtures/live-app.ts
@@ -10,17 +10,33 @@ export const FIRESTORE_PROJECT_ID = 'demo-local';
 export interface LiveApp {
   readonly app: ElectronApplication;
   readonly page: Page;
+  readonly userDataDir: string;
   readonly close: () => Promise<void>;
 }
 
-export async function openLiveApp(): Promise<LiveApp> {
+export interface OpenLiveAppOptions {
+  readonly activityExportFileName?: string;
+}
+
+export async function openLiveApp(options: OpenLiveAppOptions = {}): Promise<LiveApp> {
   const userDataDir = await mkdtemp(join(tmpdir(), 'firebase-desk-e2e-'));
-  const app = await launchDesktop({ args: ['--data-mode=live'], userDataDir });
+  const app = await launchDesktop({
+    args: ['--data-mode=live'],
+    ...(options.activityExportFileName
+      ? {
+        env: {
+          FIREBASE_DESK_ACTIVITY_EXPORT_PATH: join(userDataDir, options.activityExportFileName),
+        },
+      }
+      : {}),
+    userDataDir,
+  });
   const page = await app.firstWindow();
   await expect(page).toHaveTitle(/Firebase Desk/);
   return {
     app,
     page,
+    userDataDir,
     close: async () => {
       await app.close();
       await rm(userDataDir, { force: true, recursive: true });

--- a/e2e/specs/firestore-smoke.spec.ts
+++ b/e2e/specs/firestore-smoke.spec.ts
@@ -1,4 +1,6 @@
 import { expect, type Page, test } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { replaceMonacoEditorValue } from '../fixtures/editor.ts';
 import {
   deleteFirestoreEmulatorDocument,
@@ -13,9 +15,10 @@ import {
 } from '../fixtures/live-app.ts';
 
 test('Firestore query, create, edit, conflict, and delete flows use emulator UI', async () => {
-  const live = await openLiveApp();
+  const live = await openLiveApp({ activityExportFileName: 'activity-export.jsonl' });
   try {
     const page = live.page;
+    const activityExportPath = join(live.userDataDir, 'activity-export.jsonl');
     const suffix = uniqueSmokeId('ui');
     await addLocalEmulatorAccount(page);
     await openFirestore(page);
@@ -39,6 +42,10 @@ test('Firestore query, create, edit, conflict, and delete flows use emulator UI'
 
     await test.step('delete document with selected subcollection through UI', async () => {
       await deleteWithSelectedSubcollection(page, suffix);
+    });
+
+    await test.step('activity trail records UI actions and exports detail mode', async () => {
+      await verifyActivityTrail(page, suffix, activityExportPath);
     });
   } finally {
     await live.close();
@@ -312,6 +319,52 @@ async function deleteWithSelectedSubcollection(page: Page, suffix: string): Prom
   await deleteFirestoreEmulatorDocument(keptChildPath);
 }
 
+async function verifyActivityTrail(
+  page: Page,
+  suffix: string,
+  activityExportPath: string,
+): Promise<void> {
+  await openActivity(page);
+  const activity = page.getByRole('region', { name: 'Activity' });
+  await expect(activity.getByText('Create document').first()).toBeVisible();
+  await expect(activity.getByText('Save document').first()).toBeVisible();
+  await expect(activity.getByText('Delete document').first()).toBeVisible();
+
+  await page.getByRole('button', { name: 'Settings' }).click();
+  const settings = page.getByRole('dialog', { name: 'Settings' });
+  await expect(settings).toBeVisible();
+  await settings.getByLabel('Activity detail').selectOption('fullPayload');
+  await expect(settings.getByLabel('Activity detail')).toHaveValue('fullPayload');
+  await expect(settings.getByText(/fullPayload, 5 MB/)).toBeVisible();
+  await settings.getByRole('button', { name: 'Close dialog' }).click();
+  await expect(settings).toBeHidden();
+
+  const documentId = `activity-${suffix}`;
+  await runCollectionQuery(page, 'smokeUiActivity');
+  await page.getByRole('button', { name: 'New document' }).click();
+  const createDialog = page.getByRole('dialog', { name: 'New document' });
+  await expect(createDialog).toBeVisible();
+  await createDialog.getByLabel('Document ID').fill(documentId);
+  await replaceMonacoEditorValue(
+    page,
+    createDialog,
+    JSON.stringify({ source: 'activity-full-payload' }, null, 2),
+  );
+  await createDialog.getByRole('button', { name: 'Create' }).click();
+  await expectDialogHidden(createDialog, 'Activity create dialog stayed open');
+  await refreshChangedResults(page);
+  await expectResultDocumentId(page, documentId);
+
+  await openActivity(page);
+  await activity.getByRole('button', { name: 'Export' }).click();
+
+  await expect.poll(async () => readFile(activityExportPath, 'utf8').catch(() => '')).toContain(
+    'activity-full-payload',
+  );
+  const exported = await readFile(activityExportPath, 'utf8');
+  expect(exported).toContain('"payload"');
+}
+
 async function runCollectionQuery(page: Page, path: string): Promise<void> {
   await page.getByRole('tab', { name: 'Table' }).click();
   await page.getByLabel('Query path').fill(path);
@@ -360,6 +413,13 @@ async function refreshChangedResults(page: Page): Promise<void> {
   const bannerText = page.getByText('Results changed.');
   await expect(bannerText).toBeVisible();
   await bannerText.locator('xpath=..').getByRole('button', { name: 'Refresh' }).click();
+}
+
+async function openActivity(page: Page): Promise<void> {
+  const activity = page.getByRole('region', { name: 'Activity' });
+  if (await activity.count()) return;
+  await page.getByRole('button', { name: /Activity/ }).click();
+  await expect(activity).toBeVisible();
 }
 
 async function expectDialogHidden(dialog: ReturnType<Page['getByRole']>, message: string) {

--- a/e2e/specs/firestore-smoke.spec.ts
+++ b/e2e/specs/firestore-smoke.spec.ts
@@ -36,6 +36,10 @@ test('Firestore query, create, edit, conflict, and delete flows use emulator UI'
       await createAndEditDocument(page, suffix);
     });
 
+    await test.step('field patch writes preserve concurrent fields and delete fields', async () => {
+      await fieldPatchWrites(page, suffix);
+    });
+
     await test.step('resolve save conflict through UI', async () => {
       await resolveConflict(page, suffix);
     });
@@ -225,6 +229,93 @@ async function createAndEditDocument(page: Page, suffix: string): Promise<void> 
   });
 }
 
+async function fieldPatchWrites(page: Page, suffix: string): Promise<void> {
+  const documentId = `patch-${suffix}`;
+  const path = `smokeUiPatches/${documentId}`;
+  await setFirestoreEmulatorDocument(path, {
+    remote: 'base',
+    removable: 'present',
+    status: 'base',
+  });
+
+  await runCollectionQuery(page, 'smokeUiPatches');
+  await selectDocument(page, documentId);
+  await setFirestoreEmulatorDocument(path, {
+    remote: 'outside',
+    removable: 'present',
+    status: 'base',
+  });
+
+  await openFieldEdit(page, 'status', 'Edit string');
+  const statusDialog = page.getByRole('dialog', { name: 'Edit status' });
+  await statusDialog.getByLabel('Field string value').fill('patched');
+  await statusDialog.getByRole('button', { name: 'Save' }).click();
+  await expectDialogHidden(statusDialog, 'Field patch dialog stayed open');
+  await expect(page.getByText(/Document changed elsewhere/)).toBeVisible();
+  await refreshChangedResults(page);
+
+  let patched = await getFirestoreEmulatorDocument(path);
+  expect(patched?.fields).toMatchObject({
+    remote: { stringValue: 'outside' },
+    removable: { stringValue: 'present' },
+    status: { stringValue: 'patched' },
+  });
+
+  await selectDocument(page, documentId);
+  await openFieldEdit(page, 'status', 'Edit string');
+  const conflictFieldDialog = page.getByRole('dialog', { name: 'Edit status' });
+  await setFirestoreEmulatorDocument(path, {
+    remote: 'outside',
+    removable: 'present',
+    status: 'remote-conflict',
+  });
+  await conflictFieldDialog.getByLabel('Field string value').fill('local-conflict');
+  await conflictFieldDialog.getByRole('button', { name: 'Save' }).click();
+
+  const conflictDialog = page.getByRole('dialog', { name: 'Resolve save conflict' });
+  await expect(conflictDialog).toBeVisible();
+  await replaceMonacoEditorValue(
+    page,
+    conflictDialog,
+    JSON.stringify(
+      {
+        conflictResolved: true,
+        remote: 'outside',
+        removable: 'present',
+        status: 'merged-conflict',
+      },
+      null,
+      2,
+    ),
+  );
+  await conflictDialog.getByRole('button', { name: 'Save merged' }).click();
+  await expectDialogHidden(conflictDialog, 'Field conflict dialog stayed open');
+  await refreshChangedResults(page);
+
+  patched = await getFirestoreEmulatorDocument(path);
+  expect(patched?.fields).toMatchObject({
+    conflictResolved: { booleanValue: true },
+    remote: { stringValue: 'outside' },
+    removable: { stringValue: 'present' },
+    status: { stringValue: 'merged-conflict' },
+  });
+
+  await selectDocument(page, documentId);
+  await openFieldMenu(page, 'removable', 'Delete field');
+  const deleteDialog = page.getByRole('dialog', { name: 'Delete field' });
+  await deleteDialog.getByRole('button', { name: 'Delete' }).click();
+  await expectDialogHidden(deleteDialog, 'Delete field dialog stayed open');
+
+  await expect.poll(async () => (await getFirestoreEmulatorDocument(path))?.fields?.['removable'])
+    .toBeUndefined();
+  patched = await getFirestoreEmulatorDocument(path);
+  expect(patched?.fields).toMatchObject({
+    conflictResolved: { booleanValue: true },
+    remote: { stringValue: 'outside' },
+    status: { stringValue: 'merged-conflict' },
+  });
+}
+
 async function resolveConflict(page: Page, suffix: string): Promise<void> {
   const documentId = `conflict-${suffix}`;
   const path = `smokeUiConflicts/${documentId}`;
@@ -327,6 +418,7 @@ async function verifyActivityTrail(
   await openActivity(page);
   const activity = page.getByRole('region', { name: 'Activity' });
   await expect(activity.getByText('Create document').first()).toBeVisible();
+  await expect(activity.getByText('Update fields').first()).toBeVisible();
   await expect(activity.getByText('Save document').first()).toBeVisible();
   await expect(activity.getByText('Delete document').first()).toBeVisible();
 
@@ -354,6 +446,13 @@ async function verifyActivityTrail(
   await expectDialogHidden(createDialog, 'Activity create dialog stayed open');
   await refreshChangedResults(page);
   await expectResultDocumentId(page, documentId);
+  await selectDocument(page, documentId);
+  await openFieldEdit(page, 'source', 'Edit string');
+  const editDialog = page.getByRole('dialog', { name: 'Edit source' });
+  await editDialog.getByLabel('Field string value').fill('activity-patched');
+  await editDialog.getByRole('button', { name: 'Save' }).click();
+  await expectDialogHidden(editDialog, 'Activity field edit dialog stayed open');
+  await refreshChangedResults(page);
 
   await openActivity(page);
   await activity.getByRole('button', { name: 'Export' }).click();
@@ -363,6 +462,8 @@ async function verifyActivityTrail(
   );
   const exported = await readFile(activityExportPath, 'utf8');
   expect(exported).toContain('"payload"');
+  expect(exported).toContain('"operations"');
+  expect(exported).toContain('activity-patched');
 }
 
 async function runCollectionQuery(page: Page, path: string): Promise<void> {
@@ -407,6 +508,18 @@ function queryField(page: Page, name: string) {
 async function selectDocument(page: Page, documentId: string): Promise<void> {
   await resultDocumentIdCell(page, documentId).click();
   await expect(page.getByText(new RegExp(`/${escapeRegExp(documentId)}$`)).first()).toBeVisible();
+}
+
+async function openFieldEdit(page: Page, fieldName: string, menuItem: string): Promise<void> {
+  await openFieldMenu(page, fieldName, menuItem);
+  await expect(page.getByRole('dialog', { name: `Edit ${fieldName}` })).toBeVisible();
+}
+
+async function openFieldMenu(page: Page, fieldName: string, menuItem: string): Promise<void> {
+  await page.getByRole('treeitem', { name: new RegExp(`\\b${escapeRegExp(fieldName)}\\b`) })
+    .last()
+    .click({ button: 'right' });
+  await page.getByRole('menuitem', { name: menuItem }).click();
 }
 
 async function refreshChangedResults(page: Page): Promise<void> {

--- a/packages/ipc-schemas/src/activity.test.ts
+++ b/packages/ipc-schemas/src/activity.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ActivityLogAppendInputSchema,
+  ActivityLogEntrySchema,
+  ActivityLogListRequestSchema,
+  ActivityLogSettingsSchema,
+} from './activity.ts';
+
+describe('activity schemas', () => {
+  it('accepts valid settings, entries, and filters', () => {
+    expect(
+      ActivityLogSettingsSchema.parse({
+        detailMode: 'metadata',
+        enabled: true,
+        maxBytes: 5 * 1024 * 1024,
+      }),
+    ).toMatchObject({ detailMode: 'metadata', enabled: true });
+
+    expect(
+      ActivityLogEntrySchema.parse({
+        action: 'Save document',
+        area: 'firestore',
+        id: 'entry-1',
+        metadata: { fieldCount: 2 },
+        status: 'success',
+        summary: 'Saved orders/ord_1',
+        target: { path: 'orders/ord_1', type: 'firestore-document' },
+        timestamp: '2026-04-29T00:00:00.000Z',
+      }),
+    ).toMatchObject({ action: 'Save document', area: 'firestore' });
+
+    expect(
+      ActivityLogListRequestSchema.parse({
+        area: 'firestore',
+        limit: 25,
+        search: 'orders',
+        status: 'success',
+      }),
+    ).toMatchObject({ area: 'firestore', limit: 25 });
+  });
+
+  it('rejects invalid settings, entries, and filters', () => {
+    expect(() =>
+      ActivityLogSettingsSchema.parse({
+        detailMode: 'full',
+        enabled: true,
+        maxBytes: 10,
+      })
+    ).toThrow();
+    expect(() =>
+      ActivityLogAppendInputSchema.parse({
+        action: '',
+        area: 'firestore',
+        status: 'success',
+        summary: 'Saved',
+      })
+    ).toThrow();
+    expect(() => ActivityLogListRequestSchema.parse({ limit: 1001 })).toThrow();
+  });
+});

--- a/packages/ipc-schemas/src/activity.ts
+++ b/packages/ipc-schemas/src/activity.ts
@@ -1,0 +1,71 @@
+import {
+  ACTIVITY_LOG_AREAS,
+  ACTIVITY_LOG_DETAIL_MODES,
+  ACTIVITY_LOG_STATUSES,
+} from '@firebase-desk/repo-contracts';
+import { z } from 'zod';
+
+export const ActivityLogAreaSchema = z.enum(ACTIVITY_LOG_AREAS);
+export const ActivityLogStatusSchema = z.enum(ACTIVITY_LOG_STATUSES);
+export const ActivityLogDetailModeSchema = z.enum(ACTIVITY_LOG_DETAIL_MODES);
+
+export const ActivityLogSettingsSchema = z.object({
+  detailMode: ActivityLogDetailModeSchema,
+  enabled: z.boolean(),
+  maxBytes: z.number().int().min(1024).max(100 * 1024 * 1024),
+});
+
+export const ActivityLogTargetSchema = z.object({
+  connectionId: z.string().min(1).optional(),
+  label: z.string().min(1).optional(),
+  path: z.string().min(1).optional(),
+  projectId: z.string().min(1).optional(),
+  type: z.enum([
+    'auth-user',
+    'firestore-document',
+    'firestore-query',
+    'project',
+    'script',
+    'settings',
+    'workspace',
+  ]),
+  uid: z.string().min(1).optional(),
+});
+
+export const ActivityLogErrorSchema = z.object({
+  message: z.string().min(1),
+  name: z.string().min(1).optional(),
+});
+
+const RecordSchema = z.record(z.string(), z.unknown());
+
+export const ActivityLogEntrySchema = z.object({
+  action: z.string().min(1),
+  area: ActivityLogAreaSchema,
+  durationMs: z.number().finite().nonnegative().optional(),
+  error: ActivityLogErrorSchema.optional(),
+  id: z.string().min(1),
+  metadata: RecordSchema.optional(),
+  payload: RecordSchema.optional(),
+  status: ActivityLogStatusSchema,
+  summary: z.string().min(1),
+  target: ActivityLogTargetSchema.optional(),
+  timestamp: z.string().datetime(),
+});
+
+export const ActivityLogAppendInputSchema = ActivityLogEntrySchema.omit({
+  id: true,
+  timestamp: true,
+});
+
+export const ActivityLogListRequestSchema = z.object({
+  area: z.union([ActivityLogAreaSchema, z.literal('all')]).optional(),
+  limit: z.number().int().positive().max(1000).optional(),
+  search: z.string().optional(),
+  status: z.union([ActivityLogStatusSchema, z.literal('all')]).optional(),
+}).optional();
+
+export const ActivityLogExportResultSchema = z.object({
+  canceled: z.boolean(),
+  filePath: z.string().optional(),
+});

--- a/packages/ipc-schemas/src/channels.ts
+++ b/packages/ipc-schemas/src/channels.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
 import {
+  ActivityLogAppendInputSchema,
+  ActivityLogEntrySchema,
+  ActivityLogExportResultSchema,
+  ActivityLogListRequestSchema,
+} from './activity.ts';
+import {
   AuthUserSchema,
   AuthUsersPageSchema,
   ListUsersRequestSchema,
@@ -53,6 +59,22 @@ export const IPC_CHANNELS = {
   'app.openDataDirectory': {
     request: z.object({}),
     response: z.void(),
+  },
+  'activity.append': {
+    request: ActivityLogAppendInputSchema,
+    response: ActivityLogEntrySchema,
+  },
+  'activity.clear': {
+    request: z.object({}),
+    response: z.void(),
+  },
+  'activity.export': {
+    request: ActivityLogListRequestSchema,
+    response: ActivityLogExportResultSchema,
+  },
+  'activity.list': {
+    request: ActivityLogListRequestSchema,
+    response: z.array(ActivityLogEntrySchema),
   },
   'projects.list': {
     request: z.object({}),

--- a/packages/ipc-schemas/src/channels.ts
+++ b/packages/ipc-schemas/src/channels.ts
@@ -21,10 +21,12 @@ import {
   FirestoreGeneratedDocumentIdSchema,
   FirestoreResultsPageSchema,
   FirestoreSaveDocumentResultSchema,
+  FirestoreUpdateDocumentFieldsResultSchema,
   GenerateDocumentIdRequestSchema,
   ListDocumentsRequestSchema,
   RunQueryRequestSchema,
   SaveDocumentRequestSchema,
+  UpdateDocumentFieldsRequestSchema,
 } from './firestore.ts';
 import { HealthCheckRequestSchema, HealthCheckResponseSchema } from './health.ts';
 import {
@@ -135,6 +137,10 @@ export const IPC_CHANNELS = {
   'firestore.saveDocument': {
     request: SaveDocumentRequestSchema,
     response: FirestoreSaveDocumentResultSchema,
+  },
+  'firestore.updateDocumentFields': {
+    request: UpdateDocumentFieldsRequestSchema,
+    response: FirestoreUpdateDocumentFieldsResultSchema,
   },
   'firestore.deleteDocument': {
     request: DeleteDocumentRequestSchema,

--- a/packages/ipc-schemas/src/firestore.test.ts
+++ b/packages/ipc-schemas/src/firestore.test.ts
@@ -4,6 +4,7 @@ import {
   DeleteDocumentRequestSchema,
   GenerateDocumentIdRequestSchema,
   SaveDocumentRequestSchema,
+  UpdateDocumentFieldsRequestSchema,
 } from './firestore.ts';
 
 describe('Firestore IPC schemas', () => {
@@ -84,6 +85,41 @@ describe('Firestore IPC schemas', () => {
         connectionId: 'emu',
         documentPath: 'orders/ord_1',
         options: { deleteSubcollectionPaths: ['orders/ord_1/events/evt_1'] },
+      })
+    ).toThrow();
+  });
+
+  it('validates field patch requests', () => {
+    expect(() =>
+      UpdateDocumentFieldsRequestSchema.parse({
+        connectionId: 'emu',
+        documentPath: 'orders/ord_1',
+        operations: [
+          {
+            baseValue: 'draft',
+            fieldPath: ['status'],
+            type: 'set',
+            value: 'paid',
+          },
+          {
+            baseValue: true,
+            fieldPath: ['metadata', 'obsolete'],
+            type: 'delete',
+          },
+        ],
+        options: {
+          lastUpdateTime: '2026-04-29T00:00:00.000Z',
+          staleBehavior: 'save-and-notify',
+        },
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      UpdateDocumentFieldsRequestSchema.parse({
+        connectionId: 'emu',
+        documentPath: 'orders/ord_1',
+        operations: [{ fieldPath: ['__bad__'], type: 'set', value: 1 }],
+        options: { staleBehavior: 'block' },
       })
     ).toThrow();
   });

--- a/packages/ipc-schemas/src/firestore.ts
+++ b/packages/ipc-schemas/src/firestore.ts
@@ -1,7 +1,13 @@
+import { FIRESTORE_FIELD_STALE_BEHAVIORS } from '@firebase-desk/repo-contracts';
 import { z } from 'zod';
 import { pageOf, PageRequestSchema } from './pagination.ts';
 
 const PathSegmentSchema = z.string().min(1);
+const FieldPathSegmentSchema = PathSegmentSchema.refine((value) => !/^__.*__$/.test(value), {
+  message: 'Field path segments cannot match __.*__.',
+}).refine((value) => utf8ByteLength(value) <= 1500, {
+  message: 'Field path segments must be 1,500 bytes or less.',
+});
 const DocumentPathSchema = z.string().refine((path) => isDocumentPath(path), {
   message: 'Document path must have an even number of path segments.',
 });
@@ -109,6 +115,25 @@ export const FirestoreSaveDocumentOptionsSchema = z.object({
   lastUpdateTime: z.string().min(1).optional(),
 });
 
+export const FirestoreUpdateDocumentFieldsOptionsSchema = z.object({
+  lastUpdateTime: z.string().min(1).optional(),
+  staleBehavior: z.enum(FIRESTORE_FIELD_STALE_BEHAVIORS),
+});
+
+export const FirestoreFieldPatchOperationSchema = z.discriminatedUnion('type', [
+  z.object({
+    baseValue: FirestoreEncodedValueSchema.optional(),
+    fieldPath: z.array(FieldPathSegmentSchema).min(1),
+    type: z.literal('delete'),
+  }),
+  z.object({
+    baseValue: FirestoreEncodedValueSchema.optional(),
+    fieldPath: z.array(FieldPathSegmentSchema).min(1),
+    type: z.literal('set'),
+    value: FirestoreEncodedValueSchema,
+  }),
+]);
+
 export const FirestoreGeneratedDocumentIdSchema = z.object({
   documentId: DocumentIdSchema,
 });
@@ -117,6 +142,22 @@ export const FirestoreSaveDocumentResultSchema = z.discriminatedUnion('status', 
   z.object({
     status: z.literal('saved'),
     document: FirestoreDocumentResultSchema,
+  }),
+  z.object({
+    status: z.literal('conflict'),
+    remoteDocument: FirestoreDocumentResultSchema.nullable(),
+  }),
+]);
+
+export const FirestoreUpdateDocumentFieldsResultSchema = z.discriminatedUnion('status', [
+  z.object({
+    status: z.literal('saved'),
+    document: FirestoreDocumentResultSchema,
+    documentChanged: z.boolean().optional(),
+  }),
+  z.object({
+    status: z.literal('document-changed'),
+    remoteDocument: FirestoreDocumentResultSchema.nullable(),
   }),
   z.object({
     status: z.literal('conflict'),
@@ -140,6 +181,13 @@ export const SaveDocumentRequestSchema = z.object({
   documentPath: DocumentPathSchema,
   data: FirestoreDocumentDataSchema,
   options: FirestoreSaveDocumentOptionsSchema.optional(),
+});
+
+export const UpdateDocumentFieldsRequestSchema = z.object({
+  connectionId: z.string(),
+  documentPath: DocumentPathSchema,
+  operations: z.array(FirestoreFieldPatchOperationSchema).min(1),
+  options: FirestoreUpdateDocumentFieldsOptionsSchema,
 });
 
 export const GenerateDocumentIdRequestSchema = z.object({
@@ -182,4 +230,17 @@ function pathSegments(path: string): ReadonlyArray<string> {
 function isBase64(value: string): boolean {
   if (value === '') return true;
   return /^[A-Za-z0-9+/]+={0,2}$/.test(value) && value.length % 4 === 0;
+}
+
+function utf8ByteLength(value: string): number {
+  let bytes = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const codePoint = value.codePointAt(index) ?? 0;
+    if (codePoint > 0xffff) index += 1;
+    if (codePoint <= 0x7f) bytes += 1;
+    else if (codePoint <= 0x7ff) bytes += 2;
+    else if (codePoint <= 0xffff) bytes += 3;
+    else bytes += 4;
+  }
+  return bytes;
 }

--- a/packages/ipc-schemas/src/index.ts
+++ b/packages/ipc-schemas/src/index.ts
@@ -1,3 +1,4 @@
+export * from './activity.ts';
 export * from './auth.ts';
 export * from './channels.ts';
 export * from './firestore.ts';

--- a/packages/ipc-schemas/src/settings.test.ts
+++ b/packages/ipc-schemas/src/settings.test.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_ACTIVITY_LOG_SETTINGS } from '@firebase-desk/repo-contracts';
+import {
+  DEFAULT_ACTIVITY_LOG_SETTINGS,
+  DEFAULT_FIRESTORE_WRITE_SETTINGS,
+} from '@firebase-desk/repo-contracts';
 import { describe, expect, it } from 'vitest';
 import { SettingsFileSchema, SettingsPatchSchema } from './settings.ts';
 
@@ -17,15 +20,22 @@ describe('settings schemas', () => {
       }).snapshot,
     ).toMatchObject({
       activityLog: DEFAULT_ACTIVITY_LOG_SETTINGS,
+      firestoreWrites: DEFAULT_FIRESTORE_WRITE_SETTINGS,
       resultTableLayouts: {},
     });
   });
 
   it('does not default activity settings in patches', () => {
-    expect(SettingsPatchSchema.parse({ sidebarWidth: 400 })).toEqual({
-      sidebarWidth: 400,
-      resultTableLayouts: {},
-      firestoreFieldCatalogs: {},
+    expect(SettingsPatchSchema.parse({ sidebarWidth: 400 })).toEqual({ sidebarWidth: 400 });
+  });
+
+  it('validates firestore write settings in patches', () => {
+    expect(
+      SettingsPatchSchema.parse({
+        firestoreWrites: { fieldStaleBehavior: 'block' },
+      }),
+    ).toEqual({
+      firestoreWrites: { fieldStaleBehavior: 'block' },
     });
   });
 
@@ -46,7 +56,6 @@ describe('settings schemas', () => {
           columnSizing: { team: 220 },
         },
       },
-      firestoreFieldCatalogs: {},
     });
   });
 
@@ -60,7 +69,6 @@ describe('settings schemas', () => {
         },
       }),
     ).toEqual({
-      resultTableLayouts: {},
       firestoreFieldCatalogs: {
         'orders/skiers': [
           { count: 2, field: 'profile.age', types: ['number', 'array<string>'] },

--- a/packages/ipc-schemas/src/settings.test.ts
+++ b/packages/ipc-schemas/src/settings.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_ACTIVITY_LOG_SETTINGS } from '@firebase-desk/repo-contracts';
 import { describe, expect, it } from 'vitest';
 import { SettingsFileSchema, SettingsPatchSchema } from './settings.ts';
 
@@ -13,8 +14,19 @@ describe('settings schemas', () => {
           dataMode: 'mock',
           hotkeyOverrides: {},
         },
-      }).snapshot.resultTableLayouts,
-    ).toEqual({});
+      }).snapshot,
+    ).toMatchObject({
+      activityLog: DEFAULT_ACTIVITY_LOG_SETTINGS,
+      resultTableLayouts: {},
+    });
+  });
+
+  it('does not default activity settings in patches', () => {
+    expect(SettingsPatchSchema.parse({ sidebarWidth: 400 })).toEqual({
+      sidebarWidth: 400,
+      resultTableLayouts: {},
+      firestoreFieldCatalogs: {},
+    });
   });
 
   it('validates result table layouts in patches', () => {

--- a/packages/ipc-schemas/src/settings.ts
+++ b/packages/ipc-schemas/src/settings.ts
@@ -1,8 +1,10 @@
 import {
+  DEFAULT_ACTIVITY_LOG_SETTINGS,
   FIRESTORE_ARRAY_FIELD_TYPES,
   FIRESTORE_PRIMITIVE_FIELD_TYPES,
 } from '@firebase-desk/repo-contracts';
 import { z } from 'zod';
+import { ActivityLogSettingsSchema } from './activity.ts';
 
 export const HotkeyOverridesSchema = z.record(z.string(), z.string());
 
@@ -34,6 +36,7 @@ export const FirestoreFieldCatalogsSchema = z.record(
 );
 
 export const SettingsSnapshotSchema = z.object({
+  activityLog: ActivityLogSettingsSchema.default(DEFAULT_ACTIVITY_LOG_SETTINGS),
   sidebarWidth: z.number().int().nonnegative(),
   inspectorWidth: z.number().int().nonnegative(),
   theme: z.enum(['system', 'light', 'dark']),
@@ -43,7 +46,9 @@ export const SettingsSnapshotSchema = z.object({
   firestoreFieldCatalogs: FirestoreFieldCatalogsSchema.default({}),
 });
 
-export const SettingsPatchSchema = SettingsSnapshotSchema.partial();
+export const SettingsPatchSchema = SettingsSnapshotSchema.partial().extend({
+  activityLog: ActivityLogSettingsSchema.optional(),
+});
 
 export const SettingsFileSchema = z.object({
   version: z.literal(1),

--- a/packages/ipc-schemas/src/settings.ts
+++ b/packages/ipc-schemas/src/settings.ts
@@ -1,6 +1,8 @@
 import {
   DEFAULT_ACTIVITY_LOG_SETTINGS,
+  DEFAULT_FIRESTORE_WRITE_SETTINGS,
   FIRESTORE_ARRAY_FIELD_TYPES,
+  FIRESTORE_FIELD_STALE_BEHAVIORS,
   FIRESTORE_PRIMITIVE_FIELD_TYPES,
 } from '@firebase-desk/repo-contracts';
 import { z } from 'zod';
@@ -35,6 +37,10 @@ export const FirestoreFieldCatalogsSchema = z.record(
   z.array(FirestoreFieldCatalogEntrySchema),
 );
 
+export const FirestoreWriteSettingsSchema = z.object({
+  fieldStaleBehavior: z.enum(FIRESTORE_FIELD_STALE_BEHAVIORS),
+});
+
 export const SettingsSnapshotSchema = z.object({
   activityLog: ActivityLogSettingsSchema.default(DEFAULT_ACTIVITY_LOG_SETTINGS),
   sidebarWidth: z.number().int().nonnegative(),
@@ -44,10 +50,19 @@ export const SettingsSnapshotSchema = z.object({
   hotkeyOverrides: HotkeyOverridesSchema,
   resultTableLayouts: ResultTableLayoutsSchema.default({}),
   firestoreFieldCatalogs: FirestoreFieldCatalogsSchema.default({}),
+  firestoreWrites: FirestoreWriteSettingsSchema.default(DEFAULT_FIRESTORE_WRITE_SETTINGS),
 });
 
-export const SettingsPatchSchema = SettingsSnapshotSchema.partial().extend({
+export const SettingsPatchSchema = z.object({
   activityLog: ActivityLogSettingsSchema.optional(),
+  sidebarWidth: z.number().int().nonnegative().optional(),
+  inspectorWidth: z.number().int().nonnegative().optional(),
+  theme: z.enum(['system', 'light', 'dark']).optional(),
+  dataMode: DataModeSchema.optional(),
+  hotkeyOverrides: HotkeyOverridesSchema.optional(),
+  resultTableLayouts: ResultTableLayoutsSchema.optional(),
+  firestoreFieldCatalogs: FirestoreFieldCatalogsSchema.optional(),
+  firestoreWrites: FirestoreWriteSettingsSchema.optional(),
 });
 
 export const SettingsFileSchema = z.object({

--- a/packages/product-ui/src/activity/ActivityDrawer.test.tsx
+++ b/packages/product-ui/src/activity/ActivityDrawer.test.tsx
@@ -1,0 +1,135 @@
+import type { ActivityLogEntry } from '@firebase-desk/repo-contracts';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ActivityDrawer } from './ActivityDrawer.tsx';
+
+describe('ActivityDrawer', () => {
+  it('renders entries, details, and target open action', () => {
+    const onOpenTarget = vi.fn();
+    render(
+      <ActivityDrawer
+        area='all'
+        entries={[entry]}
+        open
+        search=''
+        status='all'
+        onAreaChange={vi.fn()}
+        onClear={vi.fn()}
+        onClose={vi.fn()}
+        onExport={vi.fn()}
+        onOpenTarget={onOpenTarget}
+        onSearchChange={vi.fn()}
+        onStatusChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('region', { name: 'Activity' })).toBeTruthy();
+    expect(screen.getByText('Save document')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Save document'));
+
+    expect(screen.getByText(/fieldCount/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+
+    expect(onOpenTarget).toHaveBeenCalledWith(entry);
+  });
+
+  it('emits filter, clear, and export actions', () => {
+    const onAreaChange = vi.fn();
+    const onClear = vi.fn();
+    const onExport = vi.fn();
+    const onSearchChange = vi.fn();
+    const onStatusChange = vi.fn();
+    render(
+      <ActivityDrawer
+        area='all'
+        entries={[]}
+        open
+        search=''
+        status='all'
+        onAreaChange={onAreaChange}
+        onClear={onClear}
+        onClose={vi.fn()}
+        onExport={onExport}
+        onSearchChange={onSearchChange}
+        onStatusChange={onStatusChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search activity' }), {
+      target: { value: 'orders' },
+    });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Activity area' }), {
+      target: { value: 'firestore' },
+    });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Activity status' }), {
+      target: { value: 'failure' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+
+    expect(onSearchChange).toHaveBeenCalledWith('orders');
+    expect(onAreaChange).toHaveBeenCalledWith('firestore');
+    expect(onStatusChange).toHaveBeenCalledWith('failure');
+    expect(onExport).toHaveBeenCalledTimes(1);
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits expanded changes', () => {
+    const onExpandedChange = vi.fn();
+    const { rerender } = render(
+      <ActivityDrawer
+        area='all'
+        entries={[]}
+        open
+        search=''
+        status='all'
+        onAreaChange={vi.fn()}
+        onClear={vi.fn()}
+        onClose={vi.fn()}
+        onExpandedChange={onExpandedChange}
+        onExport={vi.fn()}
+        onSearchChange={vi.fn()}
+        onStatusChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand' }));
+
+    expect(onExpandedChange).toHaveBeenCalledWith(true);
+
+    rerender(
+      <ActivityDrawer
+        area='all'
+        entries={[]}
+        expanded
+        open
+        search=''
+        status='all'
+        onAreaChange={vi.fn()}
+        onClear={vi.fn()}
+        onClose={vi.fn()}
+        onExpandedChange={onExpandedChange}
+        onExport={vi.fn()}
+        onSearchChange={vi.fn()}
+        onStatusChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse' }));
+
+    expect(onExpandedChange).toHaveBeenCalledWith(false);
+  });
+});
+
+const entry: ActivityLogEntry = {
+  action: 'Save document',
+  area: 'firestore',
+  id: 'activity-1',
+  metadata: { fieldCount: 1 },
+  status: 'success',
+  summary: 'Saved orders/ord_1',
+  target: { path: 'orders/ord_1', type: 'firestore-document' },
+  timestamp: '2026-04-29T00:00:00.000Z',
+};

--- a/packages/product-ui/src/activity/ActivityDrawer.test.tsx
+++ b/packages/product-ui/src/activity/ActivityDrawer.test.tsx
@@ -25,8 +25,12 @@ describe('ActivityDrawer', () => {
 
     expect(screen.getByRole('region', { name: 'Activity' })).toBeTruthy();
     expect(screen.getByText('Save document')).toBeTruthy();
+    expect(screen.queryByText(/fieldCount/)).toBeNull();
 
+    const details = screen.getByText('Save document').closest('details');
+    expect(details).toBeTruthy();
     fireEvent.click(screen.getByText('Save document'));
+    fireEvent(details!, new Event('toggle', { bubbles: true }));
 
     expect(screen.getByText(/fieldCount/)).toBeTruthy();
 

--- a/packages/product-ui/src/activity/ActivityDrawer.tsx
+++ b/packages/product-ui/src/activity/ActivityDrawer.tsx
@@ -7,6 +7,7 @@ import {
 } from '@firebase-desk/repo-contracts';
 import { Badge, Button, cn, DockedPanel, Input } from '@firebase-desk/ui';
 import { Download, ExternalLink, Maximize2, Minimize2, Trash2, X } from 'lucide-react';
+import { useState } from 'react';
 
 export interface ActivityDrawerProps {
   readonly area: ActivityLogArea | 'all';
@@ -118,50 +119,72 @@ export function ActivityDrawer(
             : entries.length === 0
             ? <div className='p-4 text-sm text-text-secondary'>No activity</div>
             : entries.map((entry) => (
-              <details key={entry.id} className='border-b border-border-subtle'>
-                <summary className='grid cursor-pointer grid-cols-[112px_92px_86px_minmax(0,1fr)_auto] items-center gap-2 px-3 py-2 text-xs hover:bg-action-ghost-hover'>
-                  <span className='font-mono text-text-muted'>{timeLabel(entry.timestamp)}</span>
-                  <Badge variant={badgeVariant(entry.status)}>{entry.status}</Badge>
-                  <span className='font-mono text-text-secondary'>{entry.area}</span>
-                  <span className='min-w-0 truncate text-sm text-text-primary'>
-                    {entry.action}
-                    <span className='text-text-muted'>· {entry.summary}</span>
-                  </span>
-                  <span className='flex items-center gap-2'>
-                    {entry.durationMs !== undefined
-                      ? <span className='font-mono text-text-muted'>{entry.durationMs}ms</span>
-                      : null}
-                    {onOpenTarget && entry.target
-                      ? (
-                        <Button
-                          size='xs'
-                          variant='ghost'
-                          onClick={(event) => {
-                            event.preventDefault();
-                            onOpenTarget(entry);
-                          }}
-                        >
-                          <ExternalLink size={13} aria-hidden='true' /> Open
-                        </Button>
-                      )
-                      : null}
-                  </span>
-                </summary>
-                <div className='grid gap-2 bg-bg-subtle px-3 py-2 text-xs'>
-                  {entry.target
-                    ? <ActivityDetail label='Target' value={targetLabel(entry)} />
-                    : null}
-                  {entry.error
-                    ? <ActivityDetail label='Error' value={entry.error.message} />
-                    : null}
-                  <JsonBlock label='Metadata' value={entry.metadata ?? {}} />
-                  {entry.payload ? <JsonBlock label='Payload' value={entry.payload} /> : null}
-                </div>
-              </details>
+              <ActivityEntryRow key={entry.id} entry={entry} onOpenTarget={onOpenTarget} />
             ))}
         </div>
       </div>
     </DockedPanel>
+  );
+}
+
+function ActivityEntryRow(
+  {
+    entry,
+    onOpenTarget,
+  }: {
+    readonly entry: ActivityLogEntry;
+    readonly onOpenTarget?: ((entry: ActivityLogEntry) => void) | undefined;
+  },
+) {
+  const [open, setOpen] = useState(false);
+  return (
+    <details
+      className='border-b border-border-subtle'
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+    >
+      <summary className='grid cursor-pointer grid-cols-[112px_92px_86px_minmax(0,1fr)_auto] items-center gap-2 px-3 py-2 text-xs hover:bg-action-ghost-hover'>
+        <span className='font-mono text-text-muted'>{timeLabel(entry.timestamp)}</span>
+        <Badge variant={badgeVariant(entry.status)}>{entry.status}</Badge>
+        <span className='font-mono text-text-secondary'>{entry.area}</span>
+        <span className='min-w-0 truncate text-sm text-text-primary'>
+          {entry.action}
+          <span className='text-text-muted'>· {entry.summary}</span>
+        </span>
+        <span className='flex items-center gap-2'>
+          {entry.durationMs !== undefined
+            ? <span className='font-mono text-text-muted'>{entry.durationMs}ms</span>
+            : null}
+          {onOpenTarget && entry.target
+            ? (
+              <Button
+                size='xs'
+                variant='ghost'
+                onClick={(event) => {
+                  event.preventDefault();
+                  onOpenTarget(entry);
+                }}
+              >
+                <ExternalLink size={13} aria-hidden='true' /> Open
+              </Button>
+            )
+            : null}
+        </span>
+      </summary>
+      {open
+        ? (
+          <div className='grid gap-2 bg-bg-subtle px-3 py-2 text-xs'>
+            {entry.target
+              ? <ActivityDetail label='Target' value={targetLabel(entry)} />
+              : null}
+            {entry.error
+              ? <ActivityDetail label='Error' value={entry.error.message} />
+              : null}
+            <JsonBlock label='Metadata' value={entry.metadata ?? {}} />
+            {entry.payload ? <JsonBlock label='Payload' value={entry.payload} /> : null}
+          </div>
+        )
+        : null}
+    </details>
   );
 }
 

--- a/packages/product-ui/src/activity/ActivityDrawer.tsx
+++ b/packages/product-ui/src/activity/ActivityDrawer.tsx
@@ -1,0 +1,205 @@
+import {
+  ACTIVITY_LOG_AREAS,
+  ACTIVITY_LOG_STATUSES,
+  type ActivityLogArea,
+  type ActivityLogEntry,
+  type ActivityLogStatus,
+} from '@firebase-desk/repo-contracts';
+import { Badge, Button, cn, DockedPanel, Input } from '@firebase-desk/ui';
+import { Download, ExternalLink, Maximize2, Minimize2, Trash2, X } from 'lucide-react';
+
+export interface ActivityDrawerProps {
+  readonly area: ActivityLogArea | 'all';
+  readonly entries: ReadonlyArray<ActivityLogEntry>;
+  readonly expanded?: boolean | undefined;
+  readonly isLoading?: boolean | undefined;
+  readonly onAreaChange: (area: ActivityLogArea | 'all') => void;
+  readonly onClear: () => void;
+  readonly onClose: () => void;
+  readonly onExport: () => void;
+  readonly onExpandedChange?: ((expanded: boolean) => void) | undefined;
+  readonly onOpenTarget?: ((entry: ActivityLogEntry) => void) | undefined;
+  readonly onSearchChange: (search: string) => void;
+  readonly onStatusChange: (status: ActivityLogStatus | 'all') => void;
+  readonly open: boolean;
+  readonly search: string;
+  readonly status: ActivityLogStatus | 'all';
+}
+
+export function ActivityDrawer(
+  {
+    area,
+    entries,
+    expanded = false,
+    isLoading = false,
+    onAreaChange,
+    onClear,
+    onClose,
+    onExport,
+    onExpandedChange,
+    onOpenTarget,
+    onSearchChange,
+    onStatusChange,
+    open,
+    search,
+    status,
+  }: ActivityDrawerProps,
+) {
+  if (!open) return null;
+  return (
+    <DockedPanel
+      aria-label='Activity'
+      className={cn(
+        'z-popover grid min-h-0',
+        expanded ? 'h-[70vh] max-h-[720px]' : 'h-80',
+      )}
+    >
+      <header className='flex h-10 items-center gap-2 border-b border-border-subtle px-3'>
+        <div className='min-w-0 flex-1'>
+          <div className='text-sm font-semibold text-text-primary'>Activity</div>
+        </div>
+        <Button size='xs' variant='secondary' onClick={onExport}>
+          <Download size={13} aria-hidden='true' /> Export
+        </Button>
+        {onExpandedChange
+          ? (
+            <Button
+              aria-expanded={expanded}
+              size='xs'
+              variant='secondary'
+              onClick={() => onExpandedChange(!expanded)}
+            >
+              {expanded
+                ? <Minimize2 size={13} aria-hidden='true' />
+                : <Maximize2 size={13} aria-hidden='true' />}
+              {expanded ? 'Collapse' : 'Expand'}
+            </Button>
+          )
+          : null}
+        <Button size='xs' variant='secondary' onClick={onClear}>
+          <Trash2 size={13} aria-hidden='true' /> Clear
+        </Button>
+        <Button size='xs' variant='ghost' onClick={onClose}>
+          <X size={13} aria-hidden='true' /> Close
+        </Button>
+      </header>
+      <div className='grid min-h-0 grid-rows-[auto_minmax(0,1fr)]'>
+        <div className='flex items-center gap-2 border-b border-border-subtle p-2'>
+          <Input
+            aria-label='Search activity'
+            className='min-w-0 flex-1'
+            placeholder='Search activity'
+            value={search}
+            onChange={(event) => onSearchChange(event.currentTarget.value)}
+          />
+          <select
+            aria-label='Activity area'
+            className='h-[var(--density-compact-control-height)] rounded-md border border-border bg-bg-panel px-2 text-sm text-text-primary'
+            value={area}
+            onChange={(event) => onAreaChange(event.currentTarget.value as ActivityLogArea | 'all')}
+          >
+            <option value='all'>all areas</option>
+            {ACTIVITY_LOG_AREAS.map((item) => <option key={item} value={item}>{item}</option>)}
+          </select>
+          <select
+            aria-label='Activity status'
+            className='h-[var(--density-compact-control-height)] rounded-md border border-border bg-bg-panel px-2 text-sm text-text-primary'
+            value={status}
+            onChange={(event) =>
+              onStatusChange(event.currentTarget.value as ActivityLogStatus | 'all')}
+          >
+            <option value='all'>all statuses</option>
+            {ACTIVITY_LOG_STATUSES.map((item) => <option key={item} value={item}>{item}</option>)}
+          </select>
+        </div>
+        <div className='min-h-0 overflow-auto'>
+          {isLoading
+            ? <div className='p-4 text-sm text-text-secondary'>Loading activity</div>
+            : entries.length === 0
+            ? <div className='p-4 text-sm text-text-secondary'>No activity</div>
+            : entries.map((entry) => (
+              <details key={entry.id} className='border-b border-border-subtle'>
+                <summary className='grid cursor-pointer grid-cols-[112px_92px_86px_minmax(0,1fr)_auto] items-center gap-2 px-3 py-2 text-xs hover:bg-action-ghost-hover'>
+                  <span className='font-mono text-text-muted'>{timeLabel(entry.timestamp)}</span>
+                  <Badge variant={badgeVariant(entry.status)}>{entry.status}</Badge>
+                  <span className='font-mono text-text-secondary'>{entry.area}</span>
+                  <span className='min-w-0 truncate text-sm text-text-primary'>
+                    {entry.action}
+                    <span className='text-text-muted'>· {entry.summary}</span>
+                  </span>
+                  <span className='flex items-center gap-2'>
+                    {entry.durationMs !== undefined
+                      ? <span className='font-mono text-text-muted'>{entry.durationMs}ms</span>
+                      : null}
+                    {onOpenTarget && entry.target
+                      ? (
+                        <Button
+                          size='xs'
+                          variant='ghost'
+                          onClick={(event) => {
+                            event.preventDefault();
+                            onOpenTarget(entry);
+                          }}
+                        >
+                          <ExternalLink size={13} aria-hidden='true' /> Open
+                        </Button>
+                      )
+                      : null}
+                  </span>
+                </summary>
+                <div className='grid gap-2 bg-bg-subtle px-3 py-2 text-xs'>
+                  {entry.target
+                    ? <ActivityDetail label='Target' value={targetLabel(entry)} />
+                    : null}
+                  {entry.error
+                    ? <ActivityDetail label='Error' value={entry.error.message} />
+                    : null}
+                  <JsonBlock label='Metadata' value={entry.metadata ?? {}} />
+                  {entry.payload ? <JsonBlock label='Payload' value={entry.payload} /> : null}
+                </div>
+              </details>
+            ))}
+        </div>
+      </div>
+    </DockedPanel>
+  );
+}
+
+function ActivityDetail({ label, value }: { readonly label: string; readonly value: string; }) {
+  return (
+    <div className='grid grid-cols-[80px_minmax(0,1fr)] gap-2'>
+      <span className='text-text-muted'>{label}</span>
+      <span className='min-w-0 break-all font-mono text-text-secondary'>{value}</span>
+    </div>
+  );
+}
+
+function JsonBlock({ label, value }: { readonly label: string; readonly value: unknown; }) {
+  return (
+    <div className='grid gap-1'>
+      <span className='text-text-muted'>{label}</span>
+      <pre className='max-h-32 overflow-auto rounded-md border border-border-subtle bg-bg-panel p-2 font-mono text-xs text-text-secondary'>
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    </div>
+  );
+}
+
+function badgeVariant(status: ActivityLogStatus): 'danger' | 'neutral' | 'success' | 'warning' {
+  if (status === 'success') return 'success';
+  if (status === 'failure') return 'danger';
+  if (status === 'conflict') return 'warning';
+  return 'neutral';
+}
+
+function targetLabel(entry: ActivityLogEntry): string {
+  return entry.target?.path ?? entry.target?.uid ?? entry.target?.label ?? entry.target?.type ?? '';
+}
+
+function timeLabel(timestamp: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).format(new Date(timestamp));
+}

--- a/packages/product-ui/src/activity/index.ts
+++ b/packages/product-ui/src/activity/index.ts
@@ -1,0 +1,1 @@
+export * from './ActivityDrawer.tsx';

--- a/packages/product-ui/src/appearance/AppearanceProvider.test.tsx
+++ b/packages/product-ui/src/appearance/AppearanceProvider.test.tsx
@@ -4,7 +4,10 @@ import type {
   SettingsRepository,
   SettingsSnapshot,
 } from '@firebase-desk/repo-contracts';
-import { DEFAULT_ACTIVITY_LOG_SETTINGS } from '@firebase-desk/repo-contracts';
+import {
+  DEFAULT_ACTIVITY_LOG_SETTINGS,
+  DEFAULT_FIRESTORE_WRITE_SETTINGS,
+} from '@firebase-desk/repo-contracts';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { AppearanceProvider, useAppearance } from './AppearanceProvider.tsx';
@@ -19,6 +22,7 @@ class TestSettingsRepository implements SettingsRepository {
     theme: 'system',
     resultTableLayouts: {},
     firestoreFieldCatalogs: {},
+    firestoreWrites: DEFAULT_FIRESTORE_WRITE_SETTINGS,
   };
 
   async load(): Promise<SettingsSnapshot> {
@@ -35,6 +39,7 @@ class TestSettingsRepository implements SettingsRepository {
       activityLog: patch.activityLog ?? this.snapshot.activityLog,
       resultTableLayouts: patch.resultTableLayouts ?? this.snapshot.resultTableLayouts,
       firestoreFieldCatalogs: patch.firestoreFieldCatalogs ?? this.snapshot.firestoreFieldCatalogs,
+      firestoreWrites: patch.firestoreWrites ?? this.snapshot.firestoreWrites,
     };
     return this.snapshot;
   }

--- a/packages/product-ui/src/appearance/AppearanceProvider.test.tsx
+++ b/packages/product-ui/src/appearance/AppearanceProvider.test.tsx
@@ -4,12 +4,14 @@ import type {
   SettingsRepository,
   SettingsSnapshot,
 } from '@firebase-desk/repo-contracts';
+import { DEFAULT_ACTIVITY_LOG_SETTINGS } from '@firebase-desk/repo-contracts';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { AppearanceProvider, useAppearance } from './AppearanceProvider.tsx';
 
 class TestSettingsRepository implements SettingsRepository {
   snapshot: SettingsSnapshot = {
+    activityLog: DEFAULT_ACTIVITY_LOG_SETTINGS,
     hotkeyOverrides: {},
     inspectorWidth: 360,
     sidebarWidth: 280,
@@ -30,6 +32,7 @@ class TestSettingsRepository implements SettingsRepository {
       theme: patch.theme ?? this.snapshot.theme,
       dataMode: patch.dataMode ?? this.snapshot.dataMode,
       hotkeyOverrides: patch.hotkeyOverrides ?? this.snapshot.hotkeyOverrides,
+      activityLog: patch.activityLog ?? this.snapshot.activityLog,
       resultTableLayouts: patch.resultTableLayouts ?? this.snapshot.resultTableLayouts,
       firestoreFieldCatalogs: patch.firestoreFieldCatalogs ?? this.snapshot.firestoreFieldCatalogs,
     };

--- a/packages/product-ui/src/features/firestore/FirestoreDocumentBrowser.tsx
+++ b/packages/product-ui/src/features/firestore/FirestoreDocumentBrowser.tsx
@@ -25,6 +25,7 @@ export interface FirestoreDocumentBrowserProps {
   readonly isFetchingMore?: boolean;
   readonly isLoading?: boolean;
   readonly actionErrorMessage?: string | null;
+  readonly actionNoticeMessage?: string | null;
   readonly onCreateDocument?: ((collectionPath: string) => void) | undefined;
   readonly onDeleteDocument?: ((document: FirestoreDocumentResult) => void) | undefined;
   readonly onDeleteField?: ((target: FieldEditTarget) => void) | undefined;
@@ -58,6 +59,7 @@ export function FirestoreDocumentBrowser(
     hasMore,
     header,
     actionErrorMessage = null,
+    actionNoticeMessage = null,
     isFetchingMore = false,
     isLoading = false,
     onCreateDocument,
@@ -137,6 +139,7 @@ export function FirestoreDocumentBrowser(
         isFetchingMore={isFetchingMore}
         isLoading={isLoading}
         actionErrorMessage={actionErrorMessage}
+        actionNoticeMessage={actionNoticeMessage}
         queryPath={queryPath}
         resultView={resultView}
         resultsStale={resultsStale}

--- a/packages/product-ui/src/features/firestore/FirestoreQuerySurface.editing.test.tsx
+++ b/packages/product-ui/src/features/firestore/FirestoreQuerySurface.editing.test.tsx
@@ -1,6 +1,9 @@
 import type {
   FirestoreDocumentResult,
   FirestoreSaveDocumentResult,
+  FirestoreUpdateDocumentFieldsResult,
+  SettingsRepository,
+  SettingsSnapshot,
 } from '@firebase-desk/repo-contracts';
 import { MockSettingsRepository } from '@firebase-desk/repo-mocks';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
@@ -174,66 +177,124 @@ const documentWithSubcollections: FirestoreDocumentResult = {
 
 describe('FirestoreQuerySurface editing UX', () => {
   it('quick toggles a boolean field from the selection preview', async () => {
-    const onSaveDocument = vi.fn<SaveDocument>();
-    renderSurface({ onSaveDocument });
+    const onUpdateDocumentFields = vi.fn<UpdateDocumentFields>();
+    renderSurface({ onUpdateDocumentFields });
 
     fireEvent.click(screen.getByRole('checkbox', { name: 'Toggle active' }));
 
     await waitFor(() =>
-      expect(onSaveDocument).toHaveBeenCalledWith('orders/ord_1', {
-        active: false,
-        meta: { count: 2 },
-        'a.b': 'literal',
-      }, { lastUpdateTime: document.updateTime })
+      expect(onUpdateDocumentFields).toHaveBeenCalledWith(
+        'orders/ord_1',
+        [{
+          baseValue: true,
+          fieldPath: ['active'],
+          type: 'set',
+          value: false,
+        }],
+        {
+          lastUpdateTime: document.updateTime,
+          staleBehavior: 'save-and-notify',
+        },
+      )
     );
   });
 
   it('sets a field to null and shows manual refresh banner', async () => {
-    const onSaveDocument = vi.fn<SaveDocument>();
-    renderSurface({ onSaveDocument });
+    const onUpdateDocumentFields = vi.fn<UpdateDocumentFields>();
+    renderSurface({ onUpdateDocumentFields });
 
     fireEvent.click(screen.getAllByRole('button', { name: 'set null active' })[0]!);
 
     await waitFor(() =>
-      expect(onSaveDocument).toHaveBeenCalledWith('orders/ord_1', {
-        active: null,
-        meta: { count: 2 },
-        'a.b': 'literal',
-      }, { lastUpdateTime: document.updateTime })
+      expect(onUpdateDocumentFields).toHaveBeenCalledWith(
+        'orders/ord_1',
+        [{
+          baseValue: true,
+          fieldPath: ['active'],
+          type: 'set',
+          value: null,
+        }],
+        {
+          lastUpdateTime: document.updateTime,
+          staleBehavior: 'save-and-notify',
+        },
+      )
     );
     expect(await screen.findByText('Results changed.')).toBeTruthy();
   });
 
+  it('defaults stale behavior when settings predate Firestore write settings', async () => {
+    const onUpdateDocumentFields = vi.fn<UpdateDocumentFields>();
+    renderSurface({
+      onUpdateDocumentFields,
+      settings: createLegacySettingsRepository(),
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'set null active' })[0]!);
+
+    await waitFor(() =>
+      expect(onUpdateDocumentFields).toHaveBeenCalledWith(
+        'orders/ord_1',
+        [{
+          baseValue: true,
+          fieldPath: ['active'],
+          type: 'set',
+          value: null,
+        }],
+        {
+          lastUpdateTime: document.updateTime,
+          staleBehavior: 'save-and-notify',
+        },
+      )
+    );
+  });
+
   it('confirms before deleting a field', async () => {
-    const onSaveDocument = vi.fn<SaveDocument>();
-    renderSurface({ onSaveDocument });
+    const onUpdateDocumentFields = vi.fn<UpdateDocumentFields>();
+    renderSurface({ onUpdateDocumentFields });
 
     fireEvent.click(screen.getAllByRole('button', { name: 'delete active' })[0]!);
     expect(screen.getByRole('dialog', { name: 'Delete field' })).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
     await waitFor(() =>
-      expect(onSaveDocument).toHaveBeenCalledWith('orders/ord_1', {
-        meta: { count: 2 },
-        'a.b': 'literal',
-      }, { lastUpdateTime: document.updateTime })
+      expect(onUpdateDocumentFields).toHaveBeenCalledWith(
+        'orders/ord_1',
+        [{
+          baseValue: true,
+          fieldPath: ['active'],
+          type: 'delete',
+        }],
+        {
+          lastUpdateTime: document.updateTime,
+          staleBehavior: 'save-and-notify',
+        },
+      )
     );
   });
 
   it('edits a literal dotted field name without treating it as nested', async () => {
-    const onSaveDocument = vi.fn<SaveDocument>();
-    renderSurface({ onSaveDocument });
+    const onUpdateDocumentFields = vi.fn<UpdateDocumentFields>();
+    renderSurface({ onUpdateDocumentFields });
 
     fireEvent.click(screen.getAllByRole('button', { name: 'edit a.b' })[0]!);
     fireEvent.change(screen.getByLabelText('Field string value'), { target: { value: 'changed' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() =>
-      expect(onSaveDocument).toHaveBeenCalledWith('orders/ord_1', {
-        active: true,
-        meta: { count: 2 },
-        'a.b': 'changed',
-      }, { lastUpdateTime: document.updateTime })
+      expect(onUpdateDocumentFields).toHaveBeenCalledWith(
+        'orders/ord_1',
+        [{
+          baseValue: 'literal',
+          fieldPath: ['a.b'],
+          type: 'set',
+          value: 'changed',
+        }],
+        {
+          lastUpdateTime: document.updateTime,
+          staleBehavior: 'save-and-notify',
+        },
+      )
     );
   });
 
@@ -243,7 +304,6 @@ describe('FirestoreQuerySurface editing UX', () => {
     renderSurface({
       onCreateDocument,
       onGenerateDocumentId,
-      onSaveDocument: vi.fn<SaveDocument>(),
     });
 
     fireEvent.click(screen.getAllByRole('button', { name: 'New document' })[0]!);
@@ -270,7 +330,6 @@ describe('FirestoreQuerySurface editing UX', () => {
       },
       onCreateDocument,
       onGenerateDocumentId: () => 'generated_id',
-      onSaveDocument: vi.fn<SaveDocument>(),
     });
 
     expect(await screen.findByRole('dialog', { name: 'New collection' })).toBeTruthy();
@@ -296,10 +355,11 @@ describe('FirestoreQuerySurface editing UX', () => {
       data: { active: false, meta: { count: 3 }, 'a.b': 'remote' },
       updateTime: '2026-04-29T00:01:00.000Z',
     };
+    const onUpdateDocumentFields = vi.fn<UpdateDocumentFields>()
+      .mockResolvedValueOnce({ status: 'conflict', remoteDocument });
     const onSaveDocument = vi.fn<SaveDocument>()
-      .mockResolvedValueOnce({ status: 'conflict', remoteDocument })
       .mockResolvedValueOnce({ status: 'saved', document: remoteDocument });
-    renderSurface({ onSaveDocument });
+    renderSurface({ onSaveDocument, onUpdateDocumentFields });
 
     fireEvent.click(screen.getAllByRole('button', { name: 'set null active' })[0]!);
     expect(await screen.findByRole('dialog', { name: 'Resolve save conflict' })).toBeTruthy();
@@ -317,6 +377,84 @@ describe('FirestoreQuerySurface editing UX', () => {
         { lastUpdateTime: remoteDocument.updateTime },
       )
     );
+  });
+
+  it('saves stale unchanged fields by default and shows a notice', async () => {
+    const onUpdateDocumentFields = vi.fn<UpdateDocumentFields>().mockResolvedValue({
+      status: 'saved',
+      document,
+      documentChanged: true,
+    });
+    renderSurface({ onUpdateDocumentFields });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'set null active' })[0]!);
+
+    await waitFor(() => expect(onUpdateDocumentFields).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(/Document changed elsewhere/)).toBeTruthy();
+  });
+
+  it('confirms stale unchanged field writes when configured', async () => {
+    const settings = new MockSettingsRepository();
+    await settings.save({ firestoreWrites: { fieldStaleBehavior: 'confirm' } });
+    const remoteDocument = {
+      ...document,
+      updateTime: '2026-04-29T00:02:00.000Z',
+    };
+    const onUpdateDocumentFields = vi.fn<UpdateDocumentFields>()
+      .mockResolvedValueOnce({ status: 'document-changed', remoteDocument })
+      .mockResolvedValueOnce({ status: 'saved', document: remoteDocument });
+    renderSurface({ onUpdateDocumentFields, settings });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'set null active' })[0]!);
+    expect(await screen.findByRole('dialog', { name: 'Document changed elsewhere' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Save field' }));
+
+    await waitFor(() =>
+      expect(onUpdateDocumentFields).toHaveBeenLastCalledWith(
+        'orders/ord_1',
+        expect.any(Array),
+        {
+          lastUpdateTime: remoteDocument.updateTime,
+          staleBehavior: 'confirm',
+        },
+      )
+    );
+  });
+
+  it('shows an error when confirmed stale field writes fail', async () => {
+    const settings = new MockSettingsRepository();
+    await settings.save({ firestoreWrites: { fieldStaleBehavior: 'confirm' } });
+    const remoteDocument = {
+      ...document,
+      updateTime: '2026-04-29T00:02:00.000Z',
+    };
+    const onUpdateDocumentFields = vi.fn<UpdateDocumentFields>()
+      .mockResolvedValueOnce({ status: 'document-changed', remoteDocument })
+      .mockRejectedValueOnce(new Error('retry failed'));
+    renderSurface({ onUpdateDocumentFields, settings });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'set null active' })[0]!);
+    expect(await screen.findByRole('dialog', { name: 'Document changed elsewhere' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Save field' }));
+
+    expect(await screen.findByText('retry failed')).toBeTruthy();
+  });
+
+  it('blocks stale unchanged field writes when configured', async () => {
+    const settings = new MockSettingsRepository();
+    await settings.save({ firestoreWrites: { fieldStaleBehavior: 'block' } });
+    const remoteDocument = {
+      ...document,
+      updateTime: '2026-04-29T00:02:00.000Z',
+    };
+    const onUpdateDocumentFields = vi.fn<UpdateDocumentFields>()
+      .mockResolvedValueOnce({ status: 'document-changed', remoteDocument });
+    renderSurface({ onUpdateDocumentFields, settings });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'set null active' })[0]!);
+
+    expect(await screen.findByText('Document changed elsewhere. Refresh before saving this field.'))
+      .toBeTruthy();
   });
   it('confirms document delete and includes selected subcollections', async () => {
     const onSaveDocument = vi.fn<SaveDocument>();
@@ -367,6 +505,8 @@ function renderSurface(
     onCreateDocument,
     onGenerateDocumentId,
     onSaveDocument,
+    onUpdateDocumentFields,
+    settings = new MockSettingsRepository(),
   }: {
     readonly createDocumentRequest?: {
       readonly collectionPath: string;
@@ -377,11 +517,13 @@ function renderSurface(
     readonly onCreateDocument?: CreateDocument;
     readonly onDeleteDocument?: DeleteDocument;
     readonly onGenerateDocumentId?: (collectionPath: string) => Promise<string> | string;
-    readonly onSaveDocument: SaveDocument;
+    readonly onSaveDocument?: SaveDocument;
+    readonly onUpdateDocumentFields?: UpdateDocumentFields;
+    readonly settings?: SettingsRepository;
   },
 ) {
   render(
-    <AppearanceProvider settings={new MockSettingsRepository()}>
+    <AppearanceProvider settings={settings}>
       <FirestoreQuerySurface
         createDocumentRequest={createDocumentRequest}
         draft={draft}
@@ -397,8 +539,10 @@ function renderSurface(
         onOpenDocumentInNewTab={() => {}}
         onReset={() => {}}
         onRun={() => {}}
-        onSaveDocument={onSaveDocument}
+        onSaveDocument={onSaveDocument ?? vi.fn<SaveDocument>()}
+        {...(onUpdateDocumentFields ? { onUpdateDocumentFields } : {})}
         onSelectDocument={() => {}}
+        settings={settings}
       />
     </AppearanceProvider>,
   );
@@ -409,6 +553,22 @@ type SaveDocument = (
   data: Record<string, unknown>,
   options?: { readonly lastUpdateTime?: string; },
 ) => FirestoreSaveDocumentResult | void | Promise<FirestoreSaveDocumentResult | void>;
+type UpdateDocumentFields = (
+  documentPath: string,
+  operations: ReadonlyArray<{
+    readonly baseValue: unknown;
+    readonly fieldPath: ReadonlyArray<string>;
+    readonly type: 'delete' | 'set';
+    readonly value?: unknown;
+  }>,
+  options: {
+    readonly lastUpdateTime?: string;
+    readonly staleBehavior: 'block' | 'confirm' | 'save-and-notify';
+  },
+) =>
+  | FirestoreUpdateDocumentFieldsResult
+  | void
+  | Promise<FirestoreUpdateDocumentFieldsResult | void>;
 type CreateDocument = (
   collectionPath: string,
   documentId: string,
@@ -418,3 +578,16 @@ type DeleteDocument = (documentPath: string, options: DeleteDocumentOptions) => 
 type CollectionWithDocuments = NonNullable<FirestoreDocumentResult['subcollections']>[number] & {
   readonly documents: ReadonlyArray<FirestoreDocumentResult>;
 };
+
+function createLegacySettingsRepository(): SettingsRepository {
+  const delegate = new MockSettingsRepository();
+  return {
+    async load() {
+      const { firestoreWrites: _firestoreWrites, ...snapshot } = await delegate.load();
+      return snapshot as unknown as SettingsSnapshot;
+    },
+    save: (patch) => delegate.save(patch),
+    getHotkeyOverrides: () => delegate.getHotkeyOverrides(),
+    setHotkeyOverrides: (overrides) => delegate.setHotkeyOverrides(overrides),
+  };
+}

--- a/packages/product-ui/src/features/firestore/FirestoreQuerySurface.tsx
+++ b/packages/product-ui/src/features/firestore/FirestoreQuerySurface.tsx
@@ -163,6 +163,8 @@ export function FirestoreQuerySurface(
     rows,
     settings,
   });
+  // Field-level actions require patch writes; falling back to full saves would overwrite documents.
+  const fieldActionsEnabled = Boolean(onUpdateDocumentFields);
 
   useEffect(() => {
     if (!createDocumentRequest || createDocumentRequest.requestId === handledCreateRequestId) {
@@ -429,9 +431,9 @@ export function FirestoreQuerySurface(
         selectedDocumentPath={selectedDocumentPath}
         settings={settings}
         onDeleteDocument={onDeleteDocument ? setDeleteDocumentTarget : undefined}
-        onDeleteField={onUpdateDocumentFields ? setDeleteFieldTarget : undefined}
+        onDeleteField={fieldActionsEnabled ? setDeleteFieldTarget : undefined}
         onEditDocument={setEditorDocument}
-        onEditField={onUpdateDocumentFields
+        onEditField={fieldActionsEnabled
           ? (target) => {
             const document = documentForTarget(target, rows, selectedDocument);
             setFieldEditor({
@@ -451,8 +453,8 @@ export function FirestoreQuerySurface(
           ? openCreateDocument
           : undefined}
         onSelectDocument={onSelectDocument}
-        onSetFieldValue={onUpdateDocumentFields ? setFieldValue : undefined}
-        onSetFieldNull={onUpdateDocumentFields ? setFieldNull : undefined}
+        onSetFieldValue={fieldActionsEnabled ? setFieldValue : undefined}
+        onSetFieldNull={fieldActionsEnabled ? setFieldNull : undefined}
       />
       <DocumentEditorModal
         document={editorDocument}

--- a/packages/product-ui/src/features/firestore/FirestoreQuerySurface.tsx
+++ b/packages/product-ui/src/features/firestore/FirestoreQuerySurface.tsx
@@ -1,10 +1,15 @@
 import type {
   FirestoreCollectionNode,
   FirestoreDocumentResult,
+  FirestoreFieldPatchOperation,
+  FirestoreFieldStaleBehavior,
   FirestoreSaveDocumentOptions,
   FirestoreSaveDocumentResult,
+  FirestoreUpdateDocumentFieldsOptions,
+  FirestoreUpdateDocumentFieldsResult,
   SettingsRepository,
 } from '@firebase-desk/repo-contracts';
+import { normalizeFirestoreWriteSettings } from '@firebase-desk/repo-contracts';
 import { useEffect, useState } from 'react';
 import { ConfirmDialog } from './ConfirmDialog.tsx';
 import { ConflictMergeModal } from './ConflictMergeModal.tsx';
@@ -68,6 +73,14 @@ export interface FirestoreQuerySurfaceProps {
     data: Record<string, unknown>,
     options?: FirestoreSaveDocumentOptions,
   ) => Promise<FirestoreSaveDocumentResult | void> | FirestoreSaveDocumentResult | void;
+  readonly onUpdateDocumentFields?: (
+    documentPath: string,
+    operations: ReadonlyArray<FirestoreFieldPatchOperation>,
+    options: FirestoreUpdateDocumentFieldsOptions,
+  ) =>
+    | Promise<FirestoreUpdateDocumentFieldsResult | void>
+    | FirestoreUpdateDocumentFieldsResult
+    | void;
   readonly onSelectDocument: (documentPath: string) => void;
   readonly rows: ReadonlyArray<FirestoreDocumentResult>;
   readonly selectedDocument?: FirestoreDocumentResult | null;
@@ -86,17 +99,19 @@ interface CreateDocumentState {
   readonly collectionPathEditable: boolean;
 }
 
-interface SaveConflictContext {
-  readonly baseDocument: FirestoreDocumentResult | null;
-  readonly onResolve?: (() => void) | undefined;
-}
-
 interface ConflictMergeState {
-  readonly baseDocument: FirestoreDocumentResult | null;
   readonly documentPath: string;
   readonly localData: Record<string, unknown>;
   readonly onResolve?: (() => void) | undefined;
   readonly remoteDocument: FirestoreDocumentResult | null;
+}
+
+interface PendingStaleFieldPatch {
+  readonly documentPath: string;
+  readonly localData: Record<string, unknown>;
+  readonly onResolve?: (() => void) | undefined;
+  readonly operations: ReadonlyArray<FirestoreFieldPatchOperation>;
+  readonly remoteDocument: FirestoreDocumentResult;
 }
 
 export function FirestoreQuerySurface(
@@ -119,6 +134,7 @@ export function FirestoreQuerySurface(
     onRefreshResults,
     onRun,
     onSaveDocument,
+    onUpdateDocumentFields,
     onSelectDocument,
     rows,
     selectedDocument = null,
@@ -136,8 +152,12 @@ export function FirestoreQuerySurface(
   const [createDocumentState, setCreateDocumentState] = useState<CreateDocumentState | null>(null);
   const [handledCreateRequestId, setHandledCreateRequestId] = useState<number | null>(null);
   const [conflictMerge, setConflictMerge] = useState<ConflictMergeState | null>(null);
+  const [pendingStaleFieldPatch, setPendingStaleFieldPatch] = useState<
+    PendingStaleFieldPatch | null
+  >(null);
   const [resultsStale, setResultsStale] = useState(false);
   const [actionErrorMessage, setActionErrorMessage] = useState<string | null>(null);
+  const [actionNoticeMessage, setActionNoticeMessage] = useState<string | null>(null);
   const fieldSuggestions = useFirestoreFieldCatalog({
     queryPath: draft.path,
     rows,
@@ -165,30 +185,82 @@ export function FirestoreQuerySurface(
     await onCreateDocument?.(collectionPath, documentId, data);
     setResultsStale(true);
     setActionErrorMessage(null);
+    setActionNoticeMessage(null);
   }
 
   async function saveDocument(
     documentPath: string,
     data: Record<string, unknown>,
     options?: FirestoreSaveDocumentOptions,
-    conflictContext?: SaveConflictContext,
+    conflictContext?: { readonly onResolve?: (() => void) | undefined; },
   ): Promise<boolean> {
     validateFirestoreDocumentData(data);
     const result = await onSaveDocument?.(documentPath, data, options);
     if (result?.status === 'conflict') {
       setConflictMerge({
-        baseDocument: conflictContext?.baseDocument ?? null,
         documentPath,
         localData: data,
         onResolve: conflictContext?.onResolve,
         remoteDocument: result.remoteDocument,
       });
       setActionErrorMessage(null);
+      setActionNoticeMessage(null);
       return false;
     }
     setResultsStale(true);
     setActionErrorMessage(null);
+    setActionNoticeMessage(null);
     conflictContext?.onResolve?.();
+    return true;
+  }
+
+  async function updateDocumentFields(
+    documentPath: string,
+    operations: ReadonlyArray<FirestoreFieldPatchOperation>,
+    options: FirestoreUpdateDocumentFieldsOptions,
+    context: {
+      readonly localData: Record<string, unknown>;
+      readonly onResolve?: (() => void) | undefined;
+    },
+  ): Promise<boolean> {
+    if (!onUpdateDocumentFields) throw new Error('Firestore field patch writes are unavailable.');
+    validateFieldPatchOperations(operations);
+    const result = await onUpdateDocumentFields?.(documentPath, operations, options);
+    if (result?.status === 'conflict') {
+      setConflictMerge({
+        documentPath,
+        localData: context.localData,
+        onResolve: context.onResolve,
+        remoteDocument: result.remoteDocument,
+      });
+      setActionErrorMessage(null);
+      setActionNoticeMessage(null);
+      return false;
+    }
+    if (result?.status === 'document-changed') {
+      setActionNoticeMessage(null);
+      if (options.staleBehavior === 'confirm' && result.remoteDocument) {
+        setPendingStaleFieldPatch({
+          documentPath,
+          localData: context.localData,
+          onResolve: context.onResolve,
+          operations,
+          remoteDocument: result.remoteDocument,
+        });
+        setActionErrorMessage(null);
+      } else {
+        setActionErrorMessage('Document changed elsewhere. Refresh before saving this field.');
+      }
+      return false;
+    }
+    setResultsStale(true);
+    setActionErrorMessage(null);
+    setActionNoticeMessage(
+      result?.status === 'saved' && result.documentChanged
+        ? 'Saved field. Document changed elsewhere; refresh to view the latest data.'
+        : null,
+    );
+    context.onResolve?.();
     return true;
   }
 
@@ -196,11 +268,22 @@ export function FirestoreQuerySurface(
     const document = documentForTarget(target, rows, selectedDocument);
     if (!document) throw new Error(`Document ${target.documentPath} is not loaded.`);
     validateFirestoreValue(value, target.fieldPath);
-    const data = setNestedFieldValue(document.data, target.fieldPath, value);
-    return await saveDocument(target.documentPath, data, saveOptionsFor(document), {
-      baseDocument: document,
-      onResolve: () => setFieldEditor(null),
-    });
+    const operation: FirestoreFieldPatchOperation = {
+      baseValue: getNestedFieldValue(document.data, target.fieldPath),
+      fieldPath: target.fieldPath,
+      type: 'set',
+      value,
+    };
+    const localData = setNestedFieldValue(document.data, target.fieldPath, value);
+    return await updateDocumentFields(
+      target.documentPath,
+      [operation],
+      await fieldOptionsFor(document),
+      {
+        localData,
+        onResolve: () => setFieldEditor(null),
+      },
+    );
   }
 
   async function setFieldNull(target: FieldEditTarget) {
@@ -223,11 +306,19 @@ export function FirestoreQuerySurface(
     try {
       const document = documentForTarget(target, rows, selectedDocument);
       if (!document) throw new Error(`Document ${target.documentPath} is not loaded.`);
-      const saved = await saveDocument(
+      const operation: FirestoreFieldPatchOperation = {
+        baseValue: getNestedFieldValue(document.data, target.fieldPath),
+        fieldPath: target.fieldPath,
+        type: 'delete',
+      };
+      const saved = await updateDocumentFields(
         target.documentPath,
-        deleteNestedFieldValue(document.data, target.fieldPath),
-        saveOptionsFor(document),
-        { baseDocument: document },
+        [operation],
+        await fieldOptionsFor(document),
+        {
+          localData: deleteNestedFieldValue(document.data, target.fieldPath),
+          onResolve: () => setDeleteFieldTarget(null),
+        },
       );
       if (saved) setDeleteFieldTarget(null);
     } catch (caught) {
@@ -245,9 +336,19 @@ export function FirestoreQuerySurface(
     }
   }
 
+  async function fieldOptionsFor(
+    document: FirestoreDocumentResult,
+  ): Promise<FirestoreUpdateDocumentFieldsOptions> {
+    return {
+      ...(document.updateTime ? { lastUpdateTime: document.updateTime } : {}),
+      staleBehavior: await loadFieldStaleBehavior(settings),
+    };
+  }
+
   function refreshResults() {
     setResultsStale(false);
     setActionErrorMessage(null);
+    setActionNoticeMessage(null);
     (onRefreshResults ?? onRun)();
   }
 
@@ -264,10 +365,7 @@ export function FirestoreQuerySurface(
       conflictMerge.documentPath,
       data,
       { lastUpdateTime: conflictMerge.remoteDocument.updateTime },
-      {
-        baseDocument: conflictMerge.remoteDocument,
-        onResolve: conflictMerge.onResolve,
-      },
+      { onResolve: conflictMerge.onResolve },
     );
     if (saved) setConflictMerge(null);
   }
@@ -277,7 +375,31 @@ export function FirestoreQuerySurface(
     setEditorDocument(null);
     setFieldEditor(null);
     setDeleteFieldTarget(null);
+    setPendingStaleFieldPatch(null);
     refreshResults();
+  }
+
+  async function confirmStaleFieldPatch() {
+    const lastUpdateTime = pendingStaleFieldPatch?.remoteDocument.updateTime;
+    if (!lastUpdateTime) return;
+    const pending = pendingStaleFieldPatch;
+    setPendingStaleFieldPatch(null);
+    try {
+      await updateDocumentFields(
+        pending.documentPath,
+        pending.operations,
+        {
+          lastUpdateTime,
+          staleBehavior: 'confirm',
+        },
+        {
+          localData: pending.localData,
+          onResolve: pending.onResolve,
+        },
+      );
+    } catch (caught) {
+      setActionErrorMessage(messageFromError(caught, 'Could not save field.'));
+    }
   }
 
   return (
@@ -298,6 +420,7 @@ export function FirestoreQuerySurface(
         isFetchingMore={isFetchingMore}
         isLoading={isLoading}
         actionErrorMessage={actionErrorMessage}
+        actionNoticeMessage={actionNoticeMessage}
         queryPath={draft.path}
         resultView={resultView}
         resultsStale={resultsStale}
@@ -306,9 +429,9 @@ export function FirestoreQuerySurface(
         selectedDocumentPath={selectedDocumentPath}
         settings={settings}
         onDeleteDocument={onDeleteDocument ? setDeleteDocumentTarget : undefined}
-        onDeleteField={onSaveDocument ? setDeleteFieldTarget : undefined}
+        onDeleteField={onUpdateDocumentFields ? setDeleteFieldTarget : undefined}
         onEditDocument={setEditorDocument}
-        onEditField={onSaveDocument
+        onEditField={onUpdateDocumentFields
           ? (target) => {
             const document = documentForTarget(target, rows, selectedDocument);
             setFieldEditor({
@@ -328,15 +451,14 @@ export function FirestoreQuerySurface(
           ? openCreateDocument
           : undefined}
         onSelectDocument={onSelectDocument}
-        onSetFieldValue={onSaveDocument ? setFieldValue : undefined}
-        onSetFieldNull={onSaveDocument ? setFieldNull : undefined}
+        onSetFieldValue={onUpdateDocumentFields ? setFieldValue : undefined}
+        onSetFieldNull={onUpdateDocumentFields ? setFieldNull : undefined}
       />
       <DocumentEditorModal
         document={editorDocument}
         open={Boolean(editorDocument)}
         onSaveDocument={(documentPath, data) =>
           saveDocument(documentPath, data, saveOptionsFor(editorDocument), {
-            baseDocument: editorDocument,
             onResolve: () => setEditorDocument(null),
           })}
         onOpenChange={(open) => {
@@ -371,6 +493,18 @@ export function FirestoreQuerySurface(
         }}
         onOpenChange={(open) => {
           if (!open) setDeleteFieldTarget(null);
+        }}
+      />
+      <ConfirmDialog
+        confirmLabel='Save field'
+        description='The document changed elsewhere, but this field still matches your loaded value. Save this field change anyway?'
+        open={Boolean(pendingStaleFieldPatch)}
+        title='Document changed elsewhere'
+        onConfirm={() => {
+          void confirmStaleFieldPatch();
+        }}
+        onOpenChange={(open) => {
+          if (!open) setPendingStaleFieldPatch(null);
         }}
       />
       <CreateDocumentModal
@@ -409,6 +543,23 @@ function saveOptionsFor(
   document: FirestoreDocumentResult | null,
 ): FirestoreSaveDocumentOptions | undefined {
   return document?.updateTime ? { lastUpdateTime: document.updateTime } : undefined;
+}
+
+async function loadFieldStaleBehavior(
+  settings: SettingsRepository | undefined,
+): Promise<FirestoreFieldStaleBehavior> {
+  return normalizeFirestoreWriteSettings((await settings?.load())?.firestoreWrites)
+    .fieldStaleBehavior;
+}
+
+function validateFieldPatchOperations(
+  operations: ReadonlyArray<FirestoreFieldPatchOperation>,
+): void {
+  if (!operations.length) throw new Error('At least one field operation is required.');
+  for (const operation of operations) {
+    if (!operation.fieldPath.length) throw new Error('Field path is required.');
+    if (operation.type === 'set') validateFirestoreValue(operation.value, operation.fieldPath);
+  }
 }
 
 function documentForTarget(

--- a/packages/product-ui/src/features/firestore/ResultPanel.tsx
+++ b/packages/product-ui/src/features/firestore/ResultPanel.tsx
@@ -32,6 +32,7 @@ export interface ResultPanelProps {
   readonly isFetchingMore: boolean;
   readonly isLoading: boolean;
   readonly actionErrorMessage?: string | null;
+  readonly actionNoticeMessage?: string | null;
   readonly resultsStale?: boolean;
   readonly onCreateDocument?: ((collectionPath: string) => void) | undefined;
   readonly onDeleteDocument?: ((document: FirestoreDocumentResult) => void) | undefined;
@@ -57,6 +58,7 @@ export function ResultPanel(
   {
     hasMore,
     actionErrorMessage = null,
+    actionNoticeMessage = null,
     errorMessage,
     isFetchingMore,
     isLoading,
@@ -166,6 +168,13 @@ export function ResultPanel(
             ? (
               <div className='border-b border-border-subtle p-2'>
                 <InlineAlert variant='danger'>{actionErrorMessage}</InlineAlert>
+              </div>
+            )
+            : null}
+          {actionNoticeMessage
+            ? (
+              <div className='border-b border-border-subtle p-2'>
+                <InlineAlert variant='warning'>{actionNoticeMessage}</InlineAlert>
               </div>
             )
             : null}

--- a/packages/product-ui/src/features/firestore/resultTableLayout.test.ts
+++ b/packages/product-ui/src/features/firestore/resultTableLayout.test.ts
@@ -1,10 +1,15 @@
-import type { SettingsRepository, SettingsSnapshot } from '@firebase-desk/repo-contracts';
+import {
+  DEFAULT_ACTIVITY_LOG_SETTINGS,
+  type SettingsRepository,
+  type SettingsSnapshot,
+} from '@firebase-desk/repo-contracts';
 import { type DataTableColumn } from '@firebase-desk/ui';
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { collectionLayoutKeyForPath, useResultTableLayout } from './resultTableLayout.ts';
 
 const settingsSnapshot: SettingsSnapshot = {
+  activityLog: DEFAULT_ACTIVITY_LOG_SETTINGS,
   dataMode: 'mock',
   firestoreFieldCatalogs: {},
   hotkeyOverrides: {},

--- a/packages/product-ui/src/features/firestore/resultTableLayout.test.ts
+++ b/packages/product-ui/src/features/firestore/resultTableLayout.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_ACTIVITY_LOG_SETTINGS,
+  DEFAULT_FIRESTORE_WRITE_SETTINGS,
   type SettingsRepository,
   type SettingsSnapshot,
 } from '@firebase-desk/repo-contracts';
@@ -12,6 +13,7 @@ const settingsSnapshot: SettingsSnapshot = {
   activityLog: DEFAULT_ACTIVITY_LOG_SETTINGS,
   dataMode: 'mock',
   firestoreFieldCatalogs: {},
+  firestoreWrites: DEFAULT_FIRESTORE_WRITE_SETTINGS,
   hotkeyOverrides: {},
   inspectorWidth: 360,
   resultTableLayouts: {},

--- a/packages/product-ui/src/index.ts
+++ b/packages/product-ui/src/index.ts
@@ -1,3 +1,4 @@
+export * from './activity/index.ts';
 export * from './app-shell/index.ts';
 export * from './appearance/index.ts';
 export * from './code-editor/index.ts';

--- a/packages/product-ui/src/settings-dialog/SettingsDialog.test.tsx
+++ b/packages/product-ui/src/settings-dialog/SettingsDialog.test.tsx
@@ -1,3 +1,4 @@
+import type { SettingsRepository, SettingsSnapshot } from '@firebase-desk/repo-contracts';
 import { MockSettingsRepository } from '@firebase-desk/repo-mocks';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
@@ -120,6 +121,53 @@ describe('SettingsDialog', () => {
       )
     );
     expect(onSettingsSaved).toHaveBeenCalled();
+  });
+
+  it('updates Firestore stale field write behavior', async () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    );
+    const settings = new MockSettingsRepository();
+    const onSettingsSaved = vi.fn();
+    render(
+      <AppearanceProvider settings={settings}>
+        <SettingsDialog open onOpenChange={vi.fn()} onSettingsSaved={onSettingsSaved} />
+      </AppearanceProvider>,
+    );
+
+    fireEvent.change(await screen.findByRole('combobox', { name: 'Stale field edits' }), {
+      target: { value: 'block' },
+    });
+
+    await waitFor(async () =>
+      expect((await settings.load()).firestoreWrites.fieldStaleBehavior).toBe('block')
+    );
+    expect(onSettingsSaved).toHaveBeenCalled();
+  });
+
+  it('defaults Firestore write settings for older saved settings', async () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    );
+    const settings = createLegacySettingsRepository();
+    render(
+      <AppearanceProvider settings={settings}>
+        <SettingsDialog open onOpenChange={vi.fn()} />
+      </AppearanceProvider>,
+    );
+
+    const select = await screen.findByRole('combobox', { name: 'Stale field edits' });
+    expect((select as HTMLSelectElement).value).toBe('save-and-notify');
   });
 
   it('keeps full payload detail when another activity setting saves before rerender', async () => {
@@ -299,3 +347,16 @@ describe('SettingsDialog', () => {
     expect(screen.getByText('About')).toBeTruthy();
   });
 });
+
+function createLegacySettingsRepository(): SettingsRepository {
+  const delegate = new MockSettingsRepository();
+  return {
+    async load() {
+      const { firestoreWrites: _firestoreWrites, ...snapshot } = await delegate.load();
+      return snapshot as unknown as SettingsSnapshot;
+    },
+    save: (patch) => delegate.save(patch),
+    getHotkeyOverrides: () => delegate.getHotkeyOverrides(),
+    setHotkeyOverrides: (overrides) => delegate.setHotkeyOverrides(overrides),
+  };
+}

--- a/packages/product-ui/src/settings-dialog/SettingsDialog.test.tsx
+++ b/packages/product-ui/src/settings-dialog/SettingsDialog.test.tsx
@@ -90,6 +90,87 @@ describe('SettingsDialog', () => {
     await waitFor(async () => expect((await settings.load()).dataMode).toBe('live'));
   });
 
+  it('updates activity settings and notifies saves', async () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    );
+    const settings = new MockSettingsRepository();
+    const onSettingsSaved = vi.fn();
+    render(
+      <AppearanceProvider settings={settings}>
+        <SettingsDialog open onOpenChange={vi.fn()} onSettingsSaved={onSettingsSaved} />
+      </AppearanceProvider>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Activity logging' }));
+    await waitFor(async () => expect((await settings.load()).activityLog.enabled).toBe(false));
+    fireEvent.change(screen.getByRole('spinbutton', { name: 'Activity retention MB' }), {
+      target: { value: '8' },
+    });
+    fireEvent.blur(screen.getByRole('spinbutton', { name: 'Activity retention MB' }));
+
+    await waitFor(async () =>
+      expect((await settings.load()).activityLog.maxBytes).toBe(
+        8 * 1024 * 1024,
+      )
+    );
+    expect(onSettingsSaved).toHaveBeenCalled();
+  });
+
+  it('keeps full payload detail when another activity setting saves before rerender', async () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    );
+    const settings = new MockSettingsRepository();
+    const { rerender } = render(
+      <AppearanceProvider settings={settings}>
+        <SettingsDialog open onOpenChange={vi.fn()} />
+      </AppearanceProvider>,
+    );
+
+    fireEvent.change(await screen.findByRole('combobox', { name: 'Activity detail' }), {
+      target: { value: 'fullPayload' },
+    });
+    fireEvent.change(screen.getByRole('spinbutton', { name: 'Activity retention MB' }), {
+      target: { value: '8' },
+    });
+    fireEvent.blur(screen.getByRole('spinbutton', { name: 'Activity retention MB' }));
+
+    await waitFor(async () =>
+      expect((await settings.load()).activityLog).toMatchObject({
+        detailMode: 'fullPayload',
+        maxBytes: 8 * 1024 * 1024,
+      })
+    );
+
+    rerender(
+      <AppearanceProvider settings={settings}>
+        <SettingsDialog open={false} onOpenChange={vi.fn()} />
+      </AppearanceProvider>,
+    );
+    rerender(
+      <AppearanceProvider settings={settings}>
+        <SettingsDialog open onOpenChange={vi.fn()} />
+      </AppearanceProvider>,
+    );
+
+    await waitFor(() =>
+      expect(
+        (screen.getByRole('combobox', { name: 'Activity detail' }) as HTMLSelectElement).value,
+      ).toBe('fullPayload')
+    );
+  });
+
   it('shows settings save failures', async () => {
     vi.stubGlobal(
       'matchMedia',

--- a/packages/product-ui/src/settings-dialog/SettingsDialog.tsx
+++ b/packages/product-ui/src/settings-dialog/SettingsDialog.tsx
@@ -2,9 +2,11 @@ import { type AppearanceMode, type DensityName } from '@firebase-desk/design-tok
 import type {
   ActivityLogDetailMode,
   DataMode,
+  FirestoreFieldStaleBehavior,
   SettingsPatch,
   SettingsSnapshot,
 } from '@firebase-desk/repo-contracts';
+import { normalizeFirestoreWriteSettings } from '@firebase-desk/repo-contracts';
 import { Button, Dialog, DialogContent, InlineAlert, Input } from '@firebase-desk/ui';
 import { FolderOpen } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
@@ -24,6 +26,11 @@ const modes: ReadonlyArray<AppearanceMode> = ['system', 'light', 'dark'];
 const dataModes: ReadonlyArray<DataMode> = ['live', 'mock'];
 const densities: ReadonlyArray<DensityName> = ['compact', 'comfortable'];
 const activityDetailModes: ReadonlyArray<ActivityLogDetailMode> = ['metadata', 'fullPayload'];
+const fieldStaleBehaviors: ReadonlyArray<FirestoreFieldStaleBehavior> = [
+  'save-and-notify',
+  'confirm',
+  'block',
+];
 const BYTES_PER_MB = 1024 * 1024;
 
 export function SettingsDialog(
@@ -105,9 +112,36 @@ export function SettingsDialog(
     }
   }
 
+  async function handleFirestoreWritesChange(
+    patch: Partial<SettingsSnapshot['firestoreWrites']>,
+  ) {
+    const currentSnapshot = settingsSnapshotRef.current ?? settingsSnapshot;
+    if (!currentSnapshot) return;
+    setSettingsError(null);
+    const firestoreWrites = {
+      ...normalizeFirestoreWriteSettings(currentSnapshot.firestoreWrites),
+      ...patch,
+    };
+    const patchToSave = { firestoreWrites };
+    const optimisticSnapshot = { ...currentSnapshot, firestoreWrites };
+    applySettingsSnapshot(optimisticSnapshot);
+    try {
+      const next = await appearance.settings.save(patchToSave);
+      applySettingsSnapshot(next);
+      onSettingsSaved?.(patchToSave, next);
+    } catch (caught) {
+      applySettingsSnapshot(currentSnapshot);
+      setSettingsError(messageFromError(caught, 'Could not save settings.'));
+    }
+  }
+
   function applySettingsSnapshot(snapshot: SettingsSnapshot) {
-    settingsSnapshotRef.current = snapshot;
-    setSettingsSnapshot(snapshot);
+    const normalizedSnapshot = {
+      ...snapshot,
+      firestoreWrites: normalizeFirestoreWriteSettings(snapshot.firestoreWrites),
+    };
+    settingsSnapshotRef.current = normalizedSnapshot;
+    setSettingsSnapshot(normalizedSnapshot);
   }
 
   function handleActivityRetentionBlur() {
@@ -217,6 +251,30 @@ export function SettingsDialog(
             </div>
           )
           : null}
+        {settingsSnapshot
+          ? (
+            <div className='grid gap-2'>
+              <div className='text-sm font-medium text-text-primary'>Firestore writes</div>
+              <select
+                aria-label='Stale field edits'
+                className='h-[var(--density-compact-control-height)] rounded-md border border-border bg-bg-panel px-2 text-sm text-text-primary'
+                value={normalizeFirestoreWriteSettings(settingsSnapshot.firestoreWrites)
+                  .fieldStaleBehavior}
+                onChange={(event) =>
+                  void handleFirestoreWritesChange({
+                    fieldStaleBehavior: event.currentTarget.value as FirestoreFieldStaleBehavior,
+                  })}
+              >
+                {fieldStaleBehaviors.map((behavior) => (
+                  <option key={behavior} value={behavior}>{behavior}</option>
+                ))}
+              </select>
+              <div className='text-xs text-text-secondary'>
+                Controls field edits when the document changed elsewhere.
+              </div>
+            </div>
+          )
+          : null}
         {density && onDensityChange
           ? (
             <div className='grid gap-2'>
@@ -309,6 +367,10 @@ function SettingsSummary({ snapshot }: { readonly snapshot: SettingsSnapshot | n
         value={`${snapshot.activityLog.detailMode}, ${
           formatMegabytes(snapshot.activityLog.maxBytes)
         } MB`}
+      />
+      <SettingRow
+        label='Field stale edits'
+        value={normalizeFirestoreWriteSettings(snapshot.firestoreWrites).fieldStaleBehavior}
       />
       <SettingRow
         label='Hotkeys'

--- a/packages/product-ui/src/settings-dialog/SettingsDialog.tsx
+++ b/packages/product-ui/src/settings-dialog/SettingsDialog.tsx
@@ -1,8 +1,13 @@
 import { type AppearanceMode, type DensityName } from '@firebase-desk/design-tokens';
-import type { DataMode, SettingsSnapshot } from '@firebase-desk/repo-contracts';
-import { Button, Dialog, DialogContent, InlineAlert } from '@firebase-desk/ui';
+import type {
+  ActivityLogDetailMode,
+  DataMode,
+  SettingsPatch,
+  SettingsSnapshot,
+} from '@firebase-desk/repo-contracts';
+import { Button, Dialog, DialogContent, InlineAlert, Input } from '@firebase-desk/ui';
 import { FolderOpen } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAppearance } from '../appearance/AppearanceProvider.tsx';
 
 export interface SettingsDialogProps {
@@ -11,12 +16,15 @@ export interface SettingsDialogProps {
   readonly onOpenChange: (open: boolean) => void;
   readonly onOpenDataDirectory?: () => Promise<void>;
   readonly onDensityChange?: (density: DensityName) => void;
+  readonly onSettingsSaved?: (patch: SettingsPatch, snapshot: SettingsSnapshot) => void;
   readonly open: boolean;
 }
 
 const modes: ReadonlyArray<AppearanceMode> = ['system', 'light', 'dark'];
 const dataModes: ReadonlyArray<DataMode> = ['live', 'mock'];
 const densities: ReadonlyArray<DensityName> = ['compact', 'comfortable'];
+const activityDetailModes: ReadonlyArray<ActivityLogDetailMode> = ['metadata', 'fullPayload'];
+const BYTES_PER_MB = 1024 * 1024;
 
 export function SettingsDialog(
   {
@@ -25,14 +33,17 @@ export function SettingsDialog(
     onDensityChange,
     onOpenChange,
     onOpenDataDirectory,
+    onSettingsSaved,
     open,
   }: SettingsDialogProps,
 ) {
   const appearance = useAppearance();
   const [settingsSnapshot, setSettingsSnapshot] = useState<SettingsSnapshot | null>(null);
+  const settingsSnapshotRef = useRef<SettingsSnapshot | null>(null);
   const [dataDirectoryError, setDataDirectoryError] = useState<string | null>(null);
   const [isOpeningDataDirectory, setIsOpeningDataDirectory] = useState(false);
   const [settingsError, setSettingsError] = useState<string | null>(null);
+  const [activityRetentionMb, setActivityRetentionMb] = useState('5');
   const [savingDataMode, setSavingDataMode] = useState<DataMode | null>(null);
   const dataDirectoryLabel = dataDirectoryPath === undefined
     ? 'Loading'
@@ -45,7 +56,10 @@ export function SettingsDialog(
     setSettingsError(null);
     appearance.settings.load()
       .then((snapshot) => {
-        if (!cancelled) setSettingsSnapshot(snapshot);
+        if (!cancelled) {
+          applySettingsSnapshot(snapshot);
+          setActivityRetentionMb(formatMegabytes(snapshot.activityLog.maxBytes));
+        }
       })
       .catch((caught) => {
         if (!cancelled) setSettingsError(messageFromError(caught, 'Could not load settings.'));
@@ -59,12 +73,46 @@ export function SettingsDialog(
     setSettingsError(null);
     setSavingDataMode(dataMode);
     try {
-      setSettingsSnapshot(await appearance.settings.save({ dataMode }));
+      const patch = { dataMode };
+      const snapshot = await appearance.settings.save(patch);
+      applySettingsSnapshot(snapshot);
+      onSettingsSaved?.(patch, snapshot);
     } catch (caught) {
       setSettingsError(messageFromError(caught, 'Could not save settings.'));
     } finally {
       setSavingDataMode(null);
     }
+  }
+
+  async function handleActivityLogChange(
+    patch: Partial<SettingsSnapshot['activityLog']>,
+  ) {
+    const currentSnapshot = settingsSnapshotRef.current ?? settingsSnapshot;
+    if (!currentSnapshot) return;
+    setSettingsError(null);
+    const activityLog = { ...currentSnapshot.activityLog, ...patch };
+    const patchToSave = { activityLog };
+    const optimisticSnapshot = { ...currentSnapshot, activityLog };
+    applySettingsSnapshot(optimisticSnapshot);
+    try {
+      const next = await appearance.settings.save(patchToSave);
+      applySettingsSnapshot(next);
+      setActivityRetentionMb(formatMegabytes(next.activityLog.maxBytes));
+      onSettingsSaved?.(patchToSave, next);
+    } catch (caught) {
+      applySettingsSnapshot(currentSnapshot);
+      setSettingsError(messageFromError(caught, 'Could not save settings.'));
+    }
+  }
+
+  function applySettingsSnapshot(snapshot: SettingsSnapshot) {
+    settingsSnapshotRef.current = snapshot;
+    setSettingsSnapshot(snapshot);
+  }
+
+  function handleActivityRetentionBlur() {
+    const maxBytes = Math.max(1, Math.round(Number(activityRetentionMb) || 5)) * BYTES_PER_MB;
+    void handleActivityLogChange({ maxBytes });
   }
 
   async function handleOpenDataDirectory() {
@@ -120,6 +168,52 @@ export function SettingsDialog(
                 ))}
               </div>
               <div className='text-xs text-text-secondary'>Changes apply immediately.</div>
+            </div>
+          )
+          : null}
+        {settingsSnapshot
+          ? (
+            <div className='grid gap-2'>
+              <div className='text-sm font-medium text-text-primary'>Activity</div>
+              <div className='flex flex-wrap items-center gap-2'>
+                <Button
+                  aria-label='Activity logging'
+                  variant={settingsSnapshot.activityLog.enabled ? 'primary' : 'secondary'}
+                  onClick={() =>
+                    void handleActivityLogChange({
+                      enabled: !settingsSnapshot.activityLog.enabled,
+                    })}
+                >
+                  {settingsSnapshot.activityLog.enabled ? 'enabled' : 'disabled'}
+                </Button>
+                <select
+                  aria-label='Activity detail'
+                  className='h-[var(--density-compact-control-height)] rounded-md border border-border bg-bg-panel px-2 text-sm text-text-primary'
+                  value={settingsSnapshot.activityLog.detailMode}
+                  onChange={(event) =>
+                    void handleActivityLogChange({
+                      detailMode: event.currentTarget.value as ActivityLogDetailMode,
+                    })}
+                >
+                  {activityDetailModes.map((mode) => <option key={mode} value={mode}>{mode}
+                  </option>)}
+                </select>
+                <label className='flex items-center gap-2 text-sm text-text-secondary'>
+                  <span>Max MB</span>
+                  <Input
+                    aria-label='Activity retention MB'
+                    className='w-24'
+                    min={1}
+                    type='number'
+                    value={activityRetentionMb}
+                    onBlur={handleActivityRetentionBlur}
+                    onChange={(event) => setActivityRetentionMb(event.currentTarget.value)}
+                  />
+                </label>
+              </div>
+              <div className='text-xs text-text-secondary'>
+                Metadata is default. Full payload stores submitted write data locally.
+              </div>
             </div>
           )
           : null}
@@ -211,11 +305,21 @@ function SettingsSummary({ snapshot }: { readonly snapshot: SettingsSnapshot | n
       <SettingRow label='Inspector' value={`${snapshot.inspectorWidth}px`} />
       <SettingRow label='Data source' value={snapshot.dataMode} />
       <SettingRow
+        label='Activity'
+        value={`${snapshot.activityLog.detailMode}, ${
+          formatMegabytes(snapshot.activityLog.maxBytes)
+        } MB`}
+      />
+      <SettingRow
         label='Hotkeys'
         value={`${Object.keys(snapshot.hotkeyOverrides).length} overrides`}
       />
     </div>
   );
+}
+
+function formatMegabytes(bytes: number): string {
+  return String(Math.max(1, Math.round(bytes / BYTES_PER_MB)));
 }
 
 function SettingRow({ label, value }: { readonly label: string; readonly value: string; }) {

--- a/packages/repo-contracts/src/activity.ts
+++ b/packages/repo-contracts/src/activity.ts
@@ -1,0 +1,99 @@
+export const ACTIVITY_LOG_AREAS = [
+  'app',
+  'auth',
+  'firestore',
+  'js-query',
+  'projects',
+  'settings',
+  'workspace',
+] as const;
+
+export type ActivityLogArea = (typeof ACTIVITY_LOG_AREAS)[number];
+
+export const ACTIVITY_LOG_STATUSES = ['cancelled', 'conflict', 'failure', 'success'] as const;
+
+export type ActivityLogStatus = (typeof ACTIVITY_LOG_STATUSES)[number];
+
+export const ACTIVITY_LOG_DETAIL_MODES = ['metadata', 'fullPayload'] as const;
+
+export type ActivityLogDetailMode = (typeof ACTIVITY_LOG_DETAIL_MODES)[number];
+
+export const DEFAULT_ACTIVITY_LOG_MAX_BYTES = 5 * 1024 * 1024;
+
+export interface ActivityLogSettings {
+  readonly detailMode: ActivityLogDetailMode;
+  readonly enabled: boolean;
+  readonly maxBytes: number;
+}
+
+export const DEFAULT_ACTIVITY_LOG_SETTINGS: ActivityLogSettings = {
+  detailMode: 'metadata',
+  enabled: true,
+  maxBytes: DEFAULT_ACTIVITY_LOG_MAX_BYTES,
+};
+
+export interface ActivityLogTarget {
+  readonly connectionId?: string | undefined;
+  readonly label?: string | undefined;
+  readonly path?: string | undefined;
+  readonly projectId?: string | undefined;
+  readonly type:
+    | 'auth-user'
+    | 'firestore-document'
+    | 'firestore-query'
+    | 'project'
+    | 'script'
+    | 'settings'
+    | 'workspace';
+  readonly uid?: string | undefined;
+}
+
+export interface ActivityLogError {
+  readonly message: string;
+  readonly name?: string | undefined;
+}
+
+export interface ActivityLogEntry {
+  readonly action: string;
+  readonly area: ActivityLogArea;
+  readonly durationMs?: number | undefined;
+  readonly error?: ActivityLogError | undefined;
+  readonly id: string;
+  readonly metadata?: Record<string, unknown> | undefined;
+  readonly payload?: Record<string, unknown> | undefined;
+  readonly status: ActivityLogStatus;
+  readonly summary: string;
+  readonly target?: ActivityLogTarget | undefined;
+  readonly timestamp: string;
+}
+
+export interface ActivityLogAppendInput {
+  readonly action: string;
+  readonly area: ActivityLogArea;
+  readonly durationMs?: number | undefined;
+  readonly error?: ActivityLogError | undefined;
+  readonly metadata?: Record<string, unknown> | undefined;
+  readonly payload?: Record<string, unknown> | undefined;
+  readonly status: ActivityLogStatus;
+  readonly summary: string;
+  readonly target?: ActivityLogTarget | undefined;
+}
+
+export interface ActivityLogListRequest {
+  readonly area?: ActivityLogArea | 'all' | undefined;
+  readonly limit?: number | undefined;
+  readonly search?: string | undefined;
+  readonly status?: ActivityLogStatus | 'all' | undefined;
+}
+
+export interface ActivityLogExportResult {
+  readonly canceled: boolean;
+  readonly filePath?: string | undefined;
+}
+
+export interface ActivityLogRepository {
+  append(input: ActivityLogAppendInput): Promise<ActivityLogEntry>;
+  clear(): Promise<void>;
+  export(request?: ActivityLogListRequest): Promise<ActivityLogExportResult>;
+  list(request?: ActivityLogListRequest): Promise<ReadonlyArray<ActivityLogEntry>>;
+}

--- a/packages/repo-contracts/src/firestore.ts
+++ b/packages/repo-contracts/src/firestore.ts
@@ -1,4 +1,5 @@
 import type { Page, PageRequest } from './pagination.ts';
+import type { FirestoreFieldStaleBehavior } from './settings.ts';
 
 export interface FirestoreCollectionNode {
   readonly path: string;
@@ -63,6 +64,24 @@ export interface FirestoreSaveDocumentOptions {
   readonly lastUpdateTime?: string;
 }
 
+export interface FirestoreUpdateDocumentFieldsOptions {
+  readonly lastUpdateTime?: string;
+  readonly staleBehavior: FirestoreFieldStaleBehavior;
+}
+
+export type FirestoreFieldPatchOperation =
+  | {
+    readonly baseValue: unknown;
+    readonly fieldPath: ReadonlyArray<string>;
+    readonly type: 'delete';
+  }
+  | {
+    readonly baseValue: unknown;
+    readonly fieldPath: ReadonlyArray<string>;
+    readonly type: 'set';
+    readonly value: unknown;
+  };
+
 export type FirestoreSaveDocumentResult =
   | {
     readonly status: 'saved';
@@ -71,6 +90,21 @@ export type FirestoreSaveDocumentResult =
   | {
     readonly status: 'conflict';
     readonly remoteDocument: FirestoreDocumentResult | null;
+  };
+
+export type FirestoreUpdateDocumentFieldsResult =
+  | {
+    readonly document: FirestoreDocumentResult;
+    readonly documentChanged?: boolean;
+    readonly status: 'saved';
+  }
+  | {
+    readonly remoteDocument: FirestoreDocumentResult | null;
+    readonly status: 'document-changed';
+  }
+  | {
+    readonly remoteDocument: FirestoreDocumentResult | null;
+    readonly status: 'conflict';
   };
 
 export interface FirestoreRepository {
@@ -105,6 +139,12 @@ export interface FirestoreRepository {
     data: Record<string, unknown>,
     options?: FirestoreSaveDocumentOptions,
   ): Promise<FirestoreSaveDocumentResult>;
+  updateDocumentFields(
+    connectionId: string,
+    documentPath: string,
+    operations: ReadonlyArray<FirestoreFieldPatchOperation>,
+    options: FirestoreUpdateDocumentFieldsOptions,
+  ): Promise<FirestoreUpdateDocumentFieldsResult>;
   deleteDocument(
     connectionId: string,
     documentPath: string,

--- a/packages/repo-contracts/src/index.ts
+++ b/packages/repo-contracts/src/index.ts
@@ -1,3 +1,4 @@
+export * from './activity.ts';
 export * from './auth.ts';
 export * from './firestore.ts';
 export * from './pagination.ts';

--- a/packages/repo-contracts/src/settings.ts
+++ b/packages/repo-contracts/src/settings.ts
@@ -1,3 +1,5 @@
+import type { ActivityLogSettings } from './activity.ts';
+
 /**
  * Future map of user-defined hotkey overrides.
  * Keys are central registry IDs (see @firebase-desk/hotkeys); values are accelerator strings.
@@ -52,6 +54,7 @@ export interface FirestoreFieldCatalogEntry {
 export type FirestoreFieldCatalogs = Record<string, FirestoreFieldCatalogEntry[]>;
 
 export interface SettingsSnapshot {
+  readonly activityLog: ActivityLogSettings;
   readonly sidebarWidth: number;
   readonly inspectorWidth: number;
   readonly theme: 'system' | 'light' | 'dark';
@@ -62,6 +65,7 @@ export interface SettingsSnapshot {
 }
 
 export interface SettingsPatch {
+  readonly activityLog?: ActivityLogSettings | undefined;
   readonly sidebarWidth?: number | undefined;
   readonly inspectorWidth?: number | undefined;
   readonly theme?: SettingsSnapshot['theme'] | undefined;

--- a/packages/repo-contracts/src/settings.ts
+++ b/packages/repo-contracts/src/settings.ts
@@ -53,6 +53,39 @@ export interface FirestoreFieldCatalogEntry {
 
 export type FirestoreFieldCatalogs = Record<string, FirestoreFieldCatalogEntry[]>;
 
+export const FIRESTORE_FIELD_STALE_BEHAVIORS = [
+  'save-and-notify',
+  'confirm',
+  'block',
+] as const;
+
+export type FirestoreFieldStaleBehavior = (typeof FIRESTORE_FIELD_STALE_BEHAVIORS)[number];
+
+export interface FirestoreWriteSettings {
+  readonly fieldStaleBehavior: FirestoreFieldStaleBehavior;
+}
+
+export const DEFAULT_FIRESTORE_WRITE_SETTINGS: FirestoreWriteSettings = {
+  fieldStaleBehavior: 'save-and-notify',
+};
+
+export function isFirestoreFieldStaleBehavior(
+  value: unknown,
+): value is FirestoreFieldStaleBehavior {
+  return typeof value === 'string'
+    && (FIRESTORE_FIELD_STALE_BEHAVIORS as ReadonlyArray<string>).includes(value);
+}
+
+export function normalizeFirestoreWriteSettings(
+  settings: Partial<FirestoreWriteSettings> | null | undefined,
+): FirestoreWriteSettings {
+  return {
+    fieldStaleBehavior: isFirestoreFieldStaleBehavior(settings?.fieldStaleBehavior)
+      ? settings.fieldStaleBehavior
+      : DEFAULT_FIRESTORE_WRITE_SETTINGS.fieldStaleBehavior,
+  };
+}
+
 export interface SettingsSnapshot {
   readonly activityLog: ActivityLogSettings;
   readonly sidebarWidth: number;
@@ -62,6 +95,7 @@ export interface SettingsSnapshot {
   readonly hotkeyOverrides: HotkeyOverrides;
   readonly resultTableLayouts: ResultTableLayouts;
   readonly firestoreFieldCatalogs: FirestoreFieldCatalogs;
+  readonly firestoreWrites: FirestoreWriteSettings;
 }
 
 export interface SettingsPatch {
@@ -73,6 +107,7 @@ export interface SettingsPatch {
   readonly hotkeyOverrides?: HotkeyOverrides | undefined;
   readonly resultTableLayouts?: ResultTableLayouts | undefined;
   readonly firestoreFieldCatalogs?: FirestoreFieldCatalogs | undefined;
+  readonly firestoreWrites?: FirestoreWriteSettings | undefined;
 }
 
 export interface SettingsRepository {

--- a/packages/repo-firebase/src/firestore-repository.test.ts
+++ b/packages/repo-firebase/src/firestore-repository.test.ts
@@ -1,5 +1,11 @@
 import type { ProjectSummary } from '@firebase-desk/repo-contracts';
-import { DocumentReference, type Firestore, GeoPoint, Timestamp } from 'firebase-admin/firestore';
+import {
+  DocumentReference,
+  FieldPath,
+  type Firestore,
+  GeoPoint,
+  Timestamp,
+} from 'firebase-admin/firestore';
 import { describe, expect, it, vi } from 'vitest';
 import type { AdminFirestoreProvider } from './admin-firestore-provider.ts';
 import { FirebaseFirestoreRepository } from './firestore-repository.ts';
@@ -136,6 +142,193 @@ describe('FirebaseFirestoreRepository', () => {
     expect(savedData).toEqual({ status: 'local' });
   });
 
+  it('updates field patches with FieldPath and never uses set', async () => {
+    let savedData: Record<string, unknown> = {
+      'a.b': 'literal',
+      nested: { count: 1 },
+      status: 'draft',
+    };
+    const ref = fakeDocumentReference('orders/ord_1', {
+      getData: () => savedData,
+      getUpdateTime: () => Timestamp.fromDate(new Date('2026-04-29T00:00:00.000Z')),
+    });
+    const transaction = {
+      get: vi.fn(async () => await ref.get()),
+      set: vi.fn(),
+      update: vi.fn((_ref: DocumentReference, fieldPath: FieldPath, value: unknown) => {
+        if (fieldPath.isEqual(new FieldPath('a.b'))) savedData = { ...savedData, 'a.b': value };
+        if (fieldPath.isEqual(new FieldPath('nested', 'count'))) {
+          savedData = { ...savedData, nested: {} };
+        }
+      }),
+    };
+    const db = {
+      doc: vi.fn(() => ref),
+      runTransaction: vi.fn(async (callback: (tx: typeof transaction) => Promise<unknown>) =>
+        await callback(transaction)
+      ),
+    } as unknown as Firestore;
+    const repository = new FirebaseFirestoreRepository(providerFor(db));
+
+    const result = await repository.updateDocumentFields(
+      'test',
+      'orders/ord_1',
+      [{
+        baseValue: 'literal',
+        fieldPath: ['a.b'],
+        type: 'set',
+        value: 'changed',
+      }, {
+        baseValue: 1,
+        fieldPath: ['nested', 'count'],
+        type: 'delete',
+      }],
+      {
+        lastUpdateTime: '2026-04-29T00:00:00.000Z',
+        staleBehavior: 'save-and-notify',
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: 'saved',
+      document: { data: { 'a.b': 'changed', nested: {} } },
+    });
+    expect(transaction.set).not.toHaveBeenCalled();
+    expect(transaction.update).toHaveBeenCalledTimes(2);
+    const firstFieldPath = transaction.update.mock.calls[0]![1] as FieldPath;
+    const secondFieldPath = transaction.update.mock.calls[1]![1] as FieldPath;
+    expect(firstFieldPath.isEqual(new FieldPath('a.b'))).toBe(true);
+    expect(secondFieldPath.isEqual(new FieldPath('nested', 'count'))).toBe(true);
+  });
+
+  it('saves stale unchanged field patches and reports documentChanged', async () => {
+    let savedData: Record<string, unknown> = { remote: 'new', status: 'draft' };
+    const ref = fakeDocumentReference('orders/ord_1', {
+      getData: () => savedData,
+      getUpdateTime: () => Timestamp.fromDate(new Date('2026-04-29T01:00:00.000Z')),
+    });
+    const transaction = {
+      get: vi.fn(async () => await ref.get()),
+      update: vi.fn((_ref: DocumentReference, fieldPath: FieldPath, value: unknown) => {
+        if (fieldPath.isEqual(new FieldPath('status'))) savedData = { ...savedData, status: value };
+      }),
+    };
+    const db = {
+      doc: vi.fn(() => ref),
+      runTransaction: vi.fn(async (callback: (tx: typeof transaction) => Promise<unknown>) =>
+        await callback(transaction)
+      ),
+    } as unknown as Firestore;
+    const repository = new FirebaseFirestoreRepository(providerFor(db));
+
+    const result = await repository.updateDocumentFields('test', 'orders/ord_1', [{
+      baseValue: 'draft',
+      fieldPath: ['status'],
+      type: 'set',
+      value: 'paid',
+    }], {
+      lastUpdateTime: '2026-04-29T00:00:00.000Z',
+      staleBehavior: 'save-and-notify',
+    });
+
+    expect(result).toMatchObject({
+      documentChanged: true,
+      status: 'saved',
+      document: { data: { remote: 'new', status: 'paid' } },
+    });
+    expect(transaction.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('classifies stale field patch conflicts without mutating', async () => {
+    const ref = fakeDocumentReference('orders/ord_1', {
+      getData: () => ({ remote: 'new', status: 'remote' }),
+      getUpdateTime: () => Timestamp.fromDate(new Date('2026-04-29T01:00:00.000Z')),
+    });
+    const transaction = {
+      get: vi.fn(async () => await ref.get()),
+      update: vi.fn(),
+    };
+    const db = {
+      doc: vi.fn(() => ref),
+      runTransaction: vi.fn(async (callback: (tx: typeof transaction) => Promise<unknown>) =>
+        await callback(transaction)
+      ),
+    } as unknown as Firestore;
+    const repository = new FirebaseFirestoreRepository(providerFor(db));
+
+    await expect(repository.updateDocumentFields('test', 'orders/ord_1', [{
+      baseValue: 'draft',
+      fieldPath: ['status'],
+      type: 'set',
+      value: 'local',
+    }], {
+      lastUpdateTime: '2026-04-29T00:00:00.000Z',
+      staleBehavior: 'save-and-notify',
+    })).resolves.toMatchObject({
+      status: 'conflict',
+      remoteDocument: { data: { status: 'remote' } },
+    });
+    expect(transaction.update).not.toHaveBeenCalled();
+  });
+
+  it('blocks stale unchanged field patches when configured', async () => {
+    const ref = fakeDocumentReference('orders/ord_1', {
+      getData: () => ({ remote: 'new', status: 'draft' }),
+      getUpdateTime: () => Timestamp.fromDate(new Date('2026-04-29T01:00:00.000Z')),
+    });
+    const transaction = {
+      get: vi.fn(async () => await ref.get()),
+      update: vi.fn(),
+    };
+    const db = {
+      doc: vi.fn(() => ref),
+      runTransaction: vi.fn(async (callback: (tx: typeof transaction) => Promise<unknown>) =>
+        await callback(transaction)
+      ),
+    } as unknown as Firestore;
+    const repository = new FirebaseFirestoreRepository(providerFor(db));
+
+    await expect(repository.updateDocumentFields('test', 'orders/ord_1', [{
+      baseValue: 'draft',
+      fieldPath: ['status'],
+      type: 'set',
+      value: 'paid',
+    }], {
+      lastUpdateTime: '2026-04-29T00:00:00.000Z',
+      staleBehavior: 'block',
+    })).resolves.toMatchObject({
+      status: 'document-changed',
+      remoteDocument: { data: { status: 'draft' } },
+    });
+    expect(transaction.update).not.toHaveBeenCalled();
+  });
+
+  it('returns field patch conflict for missing documents', async () => {
+    const ref = fakeDocumentReference('orders/missing', { exists: false });
+    const transaction = {
+      get: vi.fn(async () => await ref.get()),
+      update: vi.fn(),
+    };
+    const db = {
+      doc: vi.fn(() => ref),
+      runTransaction: vi.fn(async (callback: (tx: typeof transaction) => Promise<unknown>) =>
+        await callback(transaction)
+      ),
+    } as unknown as Firestore;
+    const repository = new FirebaseFirestoreRepository(providerFor(db));
+
+    await expect(repository.updateDocumentFields('test', 'orders/missing', [{
+      baseValue: 'draft',
+      fieldPath: ['status'],
+      type: 'set',
+      value: 'paid',
+    }], {
+      lastUpdateTime: '2026-04-29T00:00:00.000Z',
+      staleBehavior: 'save-and-notify',
+    })).resolves.toEqual({ status: 'conflict', remoteDocument: null });
+    expect(transaction.update).not.toHaveBeenCalled();
+  });
+
   it('recursively deletes selected subcollections before deleting the parent document', async () => {
     const parentDelete = vi.fn();
     const parentRef = fakeDocumentReference('orders/ord_1', { onDelete: parentDelete });
@@ -187,6 +380,9 @@ describe('FirebaseFirestoreRepository', () => {
     await expect(repository.saveDocument('test', '/orders/ord_1', {})).rejects.toThrow(
       'Invalid Firestore document path',
     );
+    await expect(repository.updateDocumentFields('test', 'orders/ord_1', [], {
+      staleBehavior: 'save-and-notify',
+    })).rejects.toThrow('At least one Firestore field operation is required.');
     await expect(repository.generateDocumentId('test', 'orders/')).rejects.toThrow(
       'Invalid Firestore collection path',
     );
@@ -232,6 +428,7 @@ function fakeDocumentReference(
   options: {
     readonly getData?: (() => Record<string, unknown>) | undefined;
     readonly getUpdateTime?: (() => Timestamp | undefined) | undefined;
+    readonly exists?: boolean | undefined;
     readonly onCreate?: ((data: Record<string, unknown>) => void | Promise<void>) | undefined;
     readonly onDelete?: (() => void | Promise<void>) | undefined;
     readonly onSet?: ((data: Record<string, unknown>) => void | Promise<void>) | undefined;
@@ -253,7 +450,7 @@ function fakeDocumentReference(
     get: {
       value: async () => ({
         data: () => options.getData?.() ?? {},
-        exists: true,
+        exists: options.exists ?? true,
         id,
         ref: fakeDocumentReference(path),
         updateTime: options.getUpdateTime?.()

--- a/packages/repo-firebase/src/firestore-repository.ts
+++ b/packages/repo-firebase/src/firestore-repository.ts
@@ -3,9 +3,12 @@ import type {
   FirestoreDeleteDocumentOptions,
   FirestoreDocumentNode,
   FirestoreDocumentResult,
+  FirestoreFieldPatchOperation,
   FirestoreRepository,
   FirestoreSaveDocumentOptions,
   FirestoreSaveDocumentResult,
+  FirestoreUpdateDocumentFieldsOptions,
+  FirestoreUpdateDocumentFieldsResult,
   Page,
   PageRequest,
 } from '@firebase-desk/repo-contracts';
@@ -13,6 +16,7 @@ import {
   type CollectionReference,
   type DocumentSnapshot,
   FieldPath,
+  FieldValue,
   type Firestore,
   type OrderByDirection,
   type Query,
@@ -172,6 +176,59 @@ export class FirebaseFirestoreRepository implements FirestoreRepository {
     });
   }
 
+  async updateDocumentFields(
+    connectionId: string,
+    documentPath: string,
+    operations: ReadonlyArray<FirestoreFieldPatchOperation>,
+    options: FirestoreUpdateDocumentFieldsOptions,
+  ): Promise<FirestoreUpdateDocumentFieldsResult> {
+    assertDocumentPath(documentPath);
+    assertFieldPatchOperations(operations);
+    return await this.withConnection(connectionId, async (db) => {
+      const ref = db.doc(documentPath);
+      const transactionResult = await db.runTransaction(async (transaction) => {
+        const current = await transaction.get(ref);
+        if (!current.exists) return { status: 'conflict' as const, remoteDocument: null };
+
+        const currentUpdateTime = snapshotUpdateTime(current);
+        const documentChanged = Boolean(
+          options.lastUpdateTime && currentUpdateTime !== options.lastUpdateTime,
+        );
+
+        if (documentChanged) {
+          const remoteDocument = await documentResult(current);
+          if (fieldPatchHasChangedRemoteValue(remoteDocument.data, operations)) {
+            return { status: 'conflict' as const, remoteDocument };
+          }
+          if (options.staleBehavior !== 'save-and-notify') {
+            return { status: 'document-changed' as const, remoteDocument };
+          }
+        }
+
+        for (const operation of operations) {
+          transaction.update(
+            ref,
+            new FieldPath(...operation.fieldPath),
+            operation.type === 'delete'
+              ? FieldValue.delete()
+              : decodeFilterValue(db, operation.value),
+          );
+        }
+        return { status: 'saved' as const, documentChanged };
+      });
+
+      if (transactionResult.status !== 'saved') return transactionResult;
+
+      const snapshot = await ref.get();
+      if (!snapshot.exists) return { status: 'conflict', remoteDocument: null };
+      return {
+        status: 'saved',
+        document: await documentResult(snapshot),
+        ...(transactionResult.documentChanged ? { documentChanged: true } : {}),
+      };
+    });
+  }
+
   async deleteDocument(
     connectionId: string,
     documentPath: string,
@@ -284,6 +341,20 @@ function assertDocumentId(id: string): void {
   }
 }
 
+function assertFieldPatchOperations(
+  operations: ReadonlyArray<FirestoreFieldPatchOperation>,
+): void {
+  if (!operations.length) throw new Error('At least one Firestore field operation is required.');
+  for (const operation of operations) {
+    if (!operation.fieldPath.length) throw new Error('Firestore field path is required.');
+    for (const segment of operation.fieldPath) {
+      if (!segment || /^__.*__$/.test(segment) || Buffer.byteLength(segment, 'utf8') > 1500) {
+        throw new Error(`Invalid Firestore field path segment: ${segment}`);
+      }
+    }
+  }
+}
+
 function assertDirectSubcollectionPath(documentPath: string, collectionPath: string): void {
   assertCollectionPath(collectionPath);
   const parentPrefix = `${documentPath}/`;
@@ -303,6 +374,50 @@ function assertDirectSubcollectionPath(documentPath: string, collectionPath: str
 function pathParts(path: string): ReadonlyArray<string> {
   const parts = path.split('/');
   return parts.some((part) => part.length === 0) ? [] : parts;
+}
+
+function fieldPatchHasChangedRemoteValue(
+  remoteData: Record<string, unknown>,
+  operations: ReadonlyArray<FirestoreFieldPatchOperation>,
+): boolean {
+  return operations.some((operation) =>
+    !deepEqual(getNestedValue(remoteData, operation.fieldPath), operation.baseValue)
+  );
+}
+
+function getNestedValue(
+  data: Record<string, unknown>,
+  fieldPath: ReadonlyArray<string>,
+): unknown {
+  let current: unknown = data;
+  for (const segment of fieldPath) {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+function deepEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(sortJson(left)) === JSON.stringify(sortJson(right));
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    sortedEntriesByKey(value as Record<string, unknown>)
+      .map(([key, entry]) => [key, sortJson(entry)]),
+  );
+}
+
+function sortedEntriesByKey(value: Record<string, unknown>): ReadonlyArray<[string, unknown]> {
+  const sorted: Array<[string, unknown]> = [];
+  for (const entry of Object.entries(value)) {
+    const index = sorted.findIndex(([key]) => entry[0].localeCompare(key) < 0);
+    if (index < 0) sorted.push(entry);
+    else sorted.splice(index, 0, entry);
+  }
+  return sorted;
 }
 
 function firestoreOperationError(caught: unknown, config: FirebaseConnectionConfig): Error {

--- a/packages/repo-mocks/src/activity.test.ts
+++ b/packages/repo-mocks/src/activity.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { MockActivityLogRepository } from './activity.ts';
+
+describe('MockActivityLogRepository', () => {
+  it('appends, lists newest first, filters, and clears', async () => {
+    const repository = new MockActivityLogRepository();
+
+    await repository.append({
+      action: 'Run query',
+      area: 'firestore',
+      status: 'success',
+      summary: 'Loaded orders',
+    });
+    await repository.append({
+      action: 'Search users',
+      area: 'auth',
+      status: 'failure',
+      summary: 'Failed users',
+    });
+
+    await expect(repository.list()).resolves.toMatchObject([
+      { action: 'Search users' },
+      { action: 'Run query' },
+    ]);
+    await expect(repository.list({ area: 'firestore' })).resolves.toMatchObject([
+      { action: 'Run query' },
+    ]);
+    await expect(repository.list({ search: 'failed' })).resolves.toMatchObject([
+      { action: 'Search users' },
+    ]);
+
+    await repository.clear();
+
+    await expect(repository.list()).resolves.toEqual([]);
+  });
+});

--- a/packages/repo-mocks/src/activity.ts
+++ b/packages/repo-mocks/src/activity.ts
@@ -1,0 +1,61 @@
+import {
+  type ActivityLogAppendInput,
+  type ActivityLogEntry,
+  type ActivityLogExportResult,
+  type ActivityLogListRequest,
+  type ActivityLogRepository,
+} from '@firebase-desk/repo-contracts';
+
+export class MockActivityLogRepository implements ActivityLogRepository {
+  private entries: ActivityLogEntry[] = [];
+  private nextId = 1;
+
+  async append(input: ActivityLogAppendInput): Promise<ActivityLogEntry> {
+    const entry: ActivityLogEntry = {
+      ...input,
+      id: `activity-${this.nextId++}`,
+      timestamp: new Date().toISOString(),
+    };
+    this.entries = [cloneEntry(entry), ...this.entries];
+    return cloneEntry(entry);
+  }
+
+  async clear(): Promise<void> {
+    this.entries = [];
+  }
+
+  async export(_request?: ActivityLogListRequest): Promise<ActivityLogExportResult> {
+    return { canceled: true };
+  }
+
+  async list(request?: ActivityLogListRequest): Promise<ReadonlyArray<ActivityLogEntry>> {
+    return filterEntries(this.entries, request).map(cloneEntry);
+  }
+}
+
+function filterEntries(
+  entries: ReadonlyArray<ActivityLogEntry>,
+  request?: ActivityLogListRequest,
+): ReadonlyArray<ActivityLogEntry> {
+  const search = request?.search?.trim().toLowerCase() ?? '';
+  return entries.filter((entry) => {
+    if (request?.area && request.area !== 'all' && entry.area !== request.area) return false;
+    if (request?.status && request.status !== 'all' && entry.status !== request.status) {
+      return false;
+    }
+    if (!search) return true;
+    return [
+      entry.action,
+      entry.area,
+      entry.status,
+      entry.summary,
+      entry.target?.label,
+      entry.target?.path,
+      entry.target?.uid,
+    ].some((value) => value?.toLowerCase().includes(search));
+  }).slice(0, request?.limit ?? entries.length);
+}
+
+function cloneEntry(entry: ActivityLogEntry): ActivityLogEntry {
+  return JSON.parse(JSON.stringify(entry)) as ActivityLogEntry;
+}

--- a/packages/repo-mocks/src/contract.test.ts
+++ b/packages/repo-mocks/src/contract.test.ts
@@ -116,6 +116,89 @@ describe('repo-mocks contract conformance', () => {
       'Invalid document path',
     );
 
+    await repo.saveDocument('p', 'orders/ord_patch', {
+      status: 'draft',
+      remote: 'old',
+      'a.b': 'literal',
+      meta: { count: 1 },
+    });
+    const patchBase = await repo.getDocument('p', 'orders/ord_patch');
+    await expect(repo.updateDocumentFields('p', 'orders/ord_patch', [{
+      baseValue: 'draft',
+      fieldPath: ['status'],
+      type: 'set',
+      value: 'paid',
+    }], {
+      lastUpdateTime: patchBase!.updateTime!,
+      staleBehavior: 'save-and-notify',
+    })).resolves.toMatchObject({
+      status: 'saved',
+      document: { data: { status: 'paid', remote: 'old', 'a.b': 'literal' } },
+    });
+    const dottedBase = await repo.getDocument('p', 'orders/ord_patch');
+    await repo.updateDocumentFields('p', 'orders/ord_patch', [{
+      baseValue: 'literal',
+      fieldPath: ['a.b'],
+      type: 'delete',
+    }], {
+      lastUpdateTime: dottedBase!.updateTime!,
+      staleBehavior: 'save-and-notify',
+    });
+    await expect(repo.getDocument('p', 'orders/ord_patch')).resolves.toMatchObject({
+      data: { status: 'paid', remote: 'old', meta: { count: 1 } },
+    });
+    expect((await repo.getDocument('p', 'orders/ord_patch'))?.data['a.b']).toBeUndefined();
+
+    const staleBase = await repo.getDocument('p', 'orders/ord_patch');
+    await repo.saveDocument('p', 'orders/ord_patch', {
+      status: 'paid',
+      remote: 'new',
+      meta: { count: 1 },
+    });
+    await expect(repo.updateDocumentFields('p', 'orders/ord_patch', [{
+      baseValue: 'paid',
+      fieldPath: ['status'],
+      type: 'set',
+      value: 'shipped',
+    }], {
+      lastUpdateTime: staleBase!.updateTime!,
+      staleBehavior: 'save-and-notify',
+    })).resolves.toMatchObject({
+      documentChanged: true,
+      status: 'saved',
+      document: { data: { status: 'shipped', remote: 'new' } },
+    });
+    const patchConflictBase = await repo.getDocument('p', 'orders/ord_patch');
+    await repo.saveDocument('p', 'orders/ord_patch', {
+      status: 'remote',
+      remote: 'new',
+      meta: { count: 1 },
+    });
+    await expect(repo.updateDocumentFields('p', 'orders/ord_patch', [{
+      baseValue: 'shipped',
+      fieldPath: ['status'],
+      type: 'set',
+      value: 'local',
+    }], {
+      lastUpdateTime: patchConflictBase!.updateTime!,
+      staleBehavior: 'save-and-notify',
+    })).resolves.toMatchObject({
+      status: 'conflict',
+      remoteDocument: { data: { status: 'remote' } },
+    });
+    await expect(repo.updateDocumentFields('p', 'orders/ord_patch', [{
+      baseValue: 'new',
+      fieldPath: ['remote'],
+      type: 'set',
+      value: 'blocked',
+    }], {
+      lastUpdateTime: patchConflictBase!.updateTime!,
+      staleBehavior: 'block',
+    })).resolves.toMatchObject({
+      status: 'document-changed',
+      remoteDocument: { data: { remote: 'new' } },
+    });
+
     const conflictBase = await repo.getDocument('p', 'orders/ord_encoded');
     expect(conflictBase?.updateTime).toBeDefined();
     await repo.saveDocument('p', 'orders/ord_encoded', { status: 'remote' });

--- a/packages/repo-mocks/src/firestore.ts
+++ b/packages/repo-mocks/src/firestore.ts
@@ -4,12 +4,15 @@ import type {
   FirestoreDeleteDocumentOptions,
   FirestoreDocumentNode,
   FirestoreDocumentResult,
+  FirestoreFieldPatchOperation,
   FirestoreFilter,
   FirestoreQuery,
   FirestoreRepository,
   FirestoreSaveDocumentOptions,
   FirestoreSaveDocumentResult,
   FirestoreSort,
+  FirestoreUpdateDocumentFieldsOptions,
+  FirestoreUpdateDocumentFieldsResult,
   Page,
   PageRequest,
 } from '@firebase-desk/repo-contracts';
@@ -155,6 +158,44 @@ export class MockFirestoreRepository implements FirestoreRepository {
     const saved = await this.getDocument(connectionId, documentPath);
     if (!saved) throw new MockFirebaseError('not-found', `Document ${documentPath} not found`);
     return { status: 'saved', document: saved };
+  }
+
+  async updateDocumentFields(
+    connectionId: string,
+    documentPath: string,
+    operations: ReadonlyArray<FirestoreFieldPatchOperation>,
+    options: FirestoreUpdateDocumentFieldsOptions,
+  ): Promise<FirestoreUpdateDocumentFieldsResult> {
+    assertConnectionAvailable(connectionId);
+    assertFieldPatchOperations(operations);
+    const { collectionPath, docId } = splitDocumentPath(documentPath);
+    const current = await this.getDocument(connectionId, documentPath);
+    if (!current) return { status: 'conflict', remoteDocument: null };
+    const documentChanged = Boolean(
+      options.lastUpdateTime && current.updateTime !== options.lastUpdateTime,
+    );
+
+    if (documentChanged) {
+      if (fieldPatchHasChangedRemoteValue(current.data, operations)) {
+        return { status: 'conflict', remoteDocument: current };
+      }
+      if (options.staleBehavior !== 'save-and-notify') {
+        return { status: 'document-changed', remoteDocument: current };
+      }
+    }
+
+    const nextData = operations.reduce(
+      (data, operation) => applyFieldPatchOperation(data, operation),
+      current.data,
+    );
+    this.writeDocument(collectionPath, docId, nextData);
+    const saved = await this.getDocument(connectionId, documentPath);
+    if (!saved) throw new MockFirebaseError('not-found', `Document ${documentPath} not found`);
+    return {
+      status: 'saved',
+      document: saved,
+      ...(documentChanged ? { documentChanged: true } : {}),
+    };
   }
 
   private writeDocument(
@@ -431,6 +472,22 @@ function assertDocumentId(documentId: string) {
   }
 }
 
+function assertFieldPatchOperations(operations: ReadonlyArray<FirestoreFieldPatchOperation>) {
+  if (!operations.length) {
+    throw new MockFirebaseError('invalid-argument', 'At least one field operation is required.');
+  }
+  for (const operation of operations) {
+    if (!operation.fieldPath.length) {
+      throw new MockFirebaseError('invalid-argument', 'Field path is required.');
+    }
+    for (const segment of operation.fieldPath) {
+      if (!segment || /^__.*__$/.test(segment) || utf8ByteLength(segment) > 1500) {
+        throw new MockFirebaseError('invalid-argument', `Invalid field path segment: ${segment}`);
+      }
+    }
+  }
+}
+
 function assertDirectSubcollectionPath(documentPath: string, collectionPath: string) {
   const documentParts = pathParts(documentPath);
   const collectionParts = pathParts(collectionPath);
@@ -461,8 +518,105 @@ function decodeDocumentData(data: Record<string, unknown>): Record<string, unkno
   return decoded;
 }
 
+function applyFieldPatchOperation(
+  data: Record<string, unknown>,
+  operation: FirestoreFieldPatchOperation,
+): Record<string, unknown> {
+  return operation.type === 'delete'
+    ? deleteNestedValue(data, operation.fieldPath)
+    : setNestedValue(data, operation.fieldPath, operation.value);
+}
+
+function setNestedValue(
+  data: Record<string, unknown>,
+  fieldPath: ReadonlyArray<string>,
+  value: unknown,
+): Record<string, unknown> {
+  const [head, ...rest] = fieldPath;
+  if (!head) return data;
+  const next = { ...data };
+  if (!rest.length) {
+    next[head] = value;
+    return next;
+  }
+  next[head] = setNestedValue(isPlainObject(next[head]) ? next[head] : {}, rest, value);
+  return next;
+}
+
+function deleteNestedValue(
+  data: Record<string, unknown>,
+  fieldPath: ReadonlyArray<string>,
+): Record<string, unknown> {
+  const [head, ...rest] = fieldPath;
+  if (!head) return data;
+  const next = { ...data };
+  if (!rest.length) {
+    delete next[head];
+    return next;
+  }
+  if (isPlainObject(next[head])) next[head] = deleteNestedValue(next[head], rest);
+  return next;
+}
+
+function fieldPatchHasChangedRemoteValue(
+  remoteData: Record<string, unknown>,
+  operations: ReadonlyArray<FirestoreFieldPatchOperation>,
+): boolean {
+  return operations.some((operation) =>
+    !deepEqual(getNestedValue(remoteData, operation.fieldPath), operation.baseValue)
+  );
+}
+
+function getNestedValue(
+  data: Record<string, unknown>,
+  fieldPath: ReadonlyArray<string>,
+): unknown {
+  let current: unknown = data;
+  for (const segment of fieldPath) {
+    if (!isPlainObject(current)) return undefined;
+    current = current[segment];
+  }
+  return current;
+}
+
+function deepEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(sortJson(left)) === JSON.stringify(sortJson(right));
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (!isPlainObject(value)) return value;
+  return Object.fromEntries(
+    sortedEntriesByKey(value)
+      .map(([key, entry]) => [key, sortJson(entry)]),
+  );
+}
+
+function sortedEntriesByKey(value: Record<string, unknown>): ReadonlyArray<[string, unknown]> {
+  const sorted: Array<[string, unknown]> = [];
+  for (const entry of Object.entries(value)) {
+    const index = sorted.findIndex(([key]) => entry[0].localeCompare(key) < 0);
+    if (index < 0) sorted.push(entry);
+    else sorted.splice(index, 0, entry);
+  }
+  return sorted;
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function utf8ByteLength(value: string): number {
+  let bytes = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const codePoint = value.codePointAt(index) ?? 0;
+    if (codePoint > 0xffff) index += 1;
+    if (codePoint <= 0x7f) bytes += 1;
+    else if (codePoint <= 0x7ff) bytes += 2;
+    else if (codePoint <= 0xffff) bytes += 3;
+    else bytes += 4;
+  }
+  return bytes;
 }
 
 function cloneCollections(

--- a/packages/repo-mocks/src/index.ts
+++ b/packages/repo-mocks/src/index.ts
@@ -1,3 +1,4 @@
+export * from './activity.ts';
 export * from './auth.ts';
 export * from './firestore.ts';
 export * from './fixtures/index.ts';

--- a/packages/repo-mocks/src/settings.ts
+++ b/packages/repo-mocks/src/settings.ts
@@ -1,11 +1,14 @@
 import type {
+  ActivityLogSettings,
   HotkeyOverrides,
   SettingsPatch,
   SettingsRepository,
   SettingsSnapshot,
 } from '@firebase-desk/repo-contracts';
+import { DEFAULT_ACTIVITY_LOG_SETTINGS } from '@firebase-desk/repo-contracts';
 
 const DEFAULT_SNAPSHOT: SettingsSnapshot = {
+  activityLog: DEFAULT_ACTIVITY_LOG_SETTINGS,
   sidebarWidth: 320,
   inspectorWidth: 360,
   theme: 'system',
@@ -24,6 +27,9 @@ export class MockSettingsRepository implements SettingsRepository {
 
   async save(patch: SettingsPatch): Promise<SettingsSnapshot> {
     this.snapshot = {
+      activityLog: patch.activityLog ? cloneActivityLogSettings(patch.activityLog) : {
+        ...this.snapshot.activityLog,
+      },
       sidebarWidth: patch.sidebarWidth ?? this.snapshot.sidebarWidth,
       inspectorWidth: patch.inspectorWidth ?? this.snapshot.inspectorWidth,
       theme: patch.theme ?? this.snapshot.theme,
@@ -53,10 +59,15 @@ export class MockSettingsRepository implements SettingsRepository {
 function cloneSnapshot(snapshot: SettingsSnapshot): SettingsSnapshot {
   return {
     ...snapshot,
+    activityLog: cloneActivityLogSettings(snapshot.activityLog),
     hotkeyOverrides: { ...snapshot.hotkeyOverrides },
     resultTableLayouts: cloneResultTableLayouts(snapshot.resultTableLayouts),
     firestoreFieldCatalogs: cloneFirestoreFieldCatalogs(snapshot.firestoreFieldCatalogs),
   };
+}
+
+function cloneActivityLogSettings(settings: ActivityLogSettings): ActivityLogSettings {
+  return { ...settings };
 }
 
 function cloneResultTableLayouts(

--- a/packages/repo-mocks/src/settings.ts
+++ b/packages/repo-mocks/src/settings.ts
@@ -5,7 +5,11 @@ import type {
   SettingsRepository,
   SettingsSnapshot,
 } from '@firebase-desk/repo-contracts';
-import { DEFAULT_ACTIVITY_LOG_SETTINGS } from '@firebase-desk/repo-contracts';
+import {
+  DEFAULT_ACTIVITY_LOG_SETTINGS,
+  DEFAULT_FIRESTORE_WRITE_SETTINGS,
+  normalizeFirestoreWriteSettings,
+} from '@firebase-desk/repo-contracts';
 
 const DEFAULT_SNAPSHOT: SettingsSnapshot = {
   activityLog: DEFAULT_ACTIVITY_LOG_SETTINGS,
@@ -16,6 +20,7 @@ const DEFAULT_SNAPSHOT: SettingsSnapshot = {
   hotkeyOverrides: {},
   resultTableLayouts: {},
   firestoreFieldCatalogs: {},
+  firestoreWrites: DEFAULT_FIRESTORE_WRITE_SETTINGS,
 };
 
 export class MockSettingsRepository implements SettingsRepository {
@@ -43,6 +48,9 @@ export class MockSettingsRepository implements SettingsRepository {
       firestoreFieldCatalogs: patch.firestoreFieldCatalogs
         ? cloneFirestoreFieldCatalogs(patch.firestoreFieldCatalogs)
         : cloneFirestoreFieldCatalogs(this.snapshot.firestoreFieldCatalogs),
+      firestoreWrites: normalizeFirestoreWriteSettings(
+        patch.firestoreWrites ?? this.snapshot.firestoreWrites,
+      ),
     };
     return this.load();
   }
@@ -63,6 +71,7 @@ function cloneSnapshot(snapshot: SettingsSnapshot): SettingsSnapshot {
     hotkeyOverrides: { ...snapshot.hotkeyOverrides },
     resultTableLayouts: cloneResultTableLayouts(snapshot.resultTableLayouts),
     firestoreFieldCatalogs: cloneFirestoreFieldCatalogs(snapshot.firestoreFieldCatalogs),
+    firestoreWrites: normalizeFirestoreWriteSettings(snapshot.firestoreWrites),
   };
 }
 

--- a/packages/ui/src/panel/Panel.test.tsx
+++ b/packages/ui/src/panel/Panel.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { Panel, PanelBody, PanelHeader } from './Panel.tsx';
+import { DockedPanel, Panel, PanelBody, PanelHeader } from './Panel.tsx';
 
 describe('Panel', () => {
   it('renders header actions and body', () => {
@@ -13,5 +13,13 @@ describe('Panel', () => {
     expect(screen.getByText('Query')).toBeDefined();
     expect(screen.getByRole('button', { name: 'Run' })).toBeDefined();
     expect(screen.getByText('Results')).toBeDefined();
+  });
+
+  it('renders a docked panel boundary', () => {
+    render(<DockedPanel aria-label='Activity'>Activity</DockedPanel>);
+
+    const panel = screen.getByRole('region', { name: 'Activity' });
+    expect(panel.className).toContain('border-t');
+    expect(panel.className).toContain('border-border-strong');
   });
 });

--- a/packages/ui/src/panel/Panel.tsx
+++ b/packages/ui/src/panel/Panel.tsx
@@ -39,3 +39,27 @@ export function PanelBody({ className, ...props }: HTMLAttributes<HTMLDivElement
     />
   );
 }
+
+export interface DockedPanelProps extends HTMLAttributes<HTMLElement> {
+  readonly edge?: 'bottom' | 'left' | 'right' | 'top';
+}
+
+const dockedPanelEdgeClasses: Record<NonNullable<DockedPanelProps['edge']>, string> = {
+  bottom: 'border-b border-border-strong',
+  left: 'border-l border-border-strong',
+  right: 'border-r border-border-strong',
+  top: 'border-t border-border-strong',
+};
+
+export function DockedPanel({ className, edge = 'top', ...props }: DockedPanelProps) {
+  return (
+    <section
+      className={cn(
+        'min-h-0 overflow-hidden bg-bg-panel',
+        dockedPanelEdgeClasses[edge],
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@tanstack/react-store':
         specifier: 0.11.0
         version: 0.11.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      firebase-admin:
+        specifier: 13.8.0
+        version: 13.8.0
       lucide-react:
         specifier: 1.11.0
         version: 1.11.0(react@19.2.5)


### PR DESCRIPTION
Introduce Firestore field stale behavior settings to enhance document handling and conflict resolution. Implement activity logging schemas and UI components, including an `ActivityDrawer` for displaying logs. Update tests to validate new functionalities and ensure compatibility with existing settings. Additionally, fix the Mac package configuration.