### PR TITLE
[codex] Add release gates

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,54 @@
+name: release gate
+
+on:
+    pull_request:
+        branches: [ main ]
+        types: [ opened, synchronize, reopened, edited ]
+
+permissions:
+    contents: read
+    pull-requests: read
+
+jobs:
+    version-bump:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/github-script@v8
+              with:
+                  script: |
+                      const skipKeyword = '[skip release]';
+                      const pullRequest = context.payload.pull_request;
+                      const title = pullRequest.title ?? '';
+
+                      if (title.includes(skipKeyword)) {
+                        core.info(`Release version gate skipped by PR title keyword ${skipKeyword}.`);
+                        return;
+                      }
+
+                      async function packageVersion(repository, ref) {
+                        const response = await github.rest.repos.getContent({
+                          owner: repository.owner.login,
+                          repo: repository.name,
+                          path: 'apps/desktop/package.json',
+                          ref,
+                        });
+                        if (!('content' in response.data)) {
+                          throw new Error('apps/desktop/package.json is not a file.');
+                        }
+                        const packageJson = JSON.parse(
+                          Buffer.from(response.data.content, 'base64').toString('utf8'),
+                        );
+                        return packageJson.version;
+                      }
+
+                      const baseVersion = await packageVersion(pullRequest.base.repo, pullRequest.base.sha);
+                      const headVersion = await packageVersion(pullRequest.head.repo, pullRequest.head.sha);
+                      const hasDesktopVersionChange = headVersion !== baseVersion;
+
+                      if (!hasDesktopVersionChange) {
+                        core.setFailed(
+                          `Change apps/desktop/package.json version, or add ${skipKeyword} to the PR title.`,
+                        );
+                      } else {
+                        core.info(`Desktop version changes from ${baseVersion} to ${headVersion}.`);
+                      }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
             matrix: ${{ steps.plan.outputs.matrix }}
             release_channel: ${{ steps.plan.outputs.release_channel }}
             retention_days: ${{ steps.plan.outputs.retention_days }}
+            should_package: ${{ steps.plan.outputs.should_package }}
         steps:
             - uses: actions/github-script@v8
               id: plan
@@ -43,12 +44,16 @@ jobs:
                           '.dockerignore',
                           '.github/workflows/ci.yml',
                           '.github/workflows/release.yml',
+                          '.github/workflows/release-gate.yml',
                           'package.json',
                           'pnpm-lock.yaml',
+                          'scripts/check-release-version.ts',
                           'scripts/generate-icons.mjs',
                           'scripts/package-desktop.mjs',
                           'scripts/package-linux-docker.sh',
+                          'scripts/write-package-manager-manifests.ts',
                           'scripts/write-package-checksums.mjs',
+                          'scripts/write-release-manifest.ts',
                       ]);
 
                       const eventName = context.eventName;
@@ -56,6 +61,7 @@ jobs:
                       let releaseChannel = `dispatch-${context.runId}`;
                       let retentionDays = '14';
                       let includeAllPlatforms = eventName === 'workflow_dispatch';
+                      let shouldPackage = true;
 
                       if (eventName === 'pull_request') {
                           const pullRequest = context.payload.pull_request;
@@ -79,6 +85,37 @@ jobs:
                           releaseChannel = 'latest';
                           retentionDays = '90';
                           includeAllPlatforms = true;
+                          const before = context.payload.before;
+                          if (before && !/^0+$/.test(before)) {
+                              async function desktopVersionAt(ref) {
+                                  const response = await github.rest.repos.getContent({
+                                      owner: context.repo.owner,
+                                      repo: context.repo.repo,
+                                      path: 'apps/desktop/package.json',
+                                      ref,
+                                  });
+                                  if (!('content' in response.data)) {
+                                      throw new Error('apps/desktop/package.json is not a file.');
+                                  }
+                                  return JSON.parse(
+                                      Buffer.from(response.data.content, 'base64').toString('utf8'),
+                                  ).version;
+                              }
+                              const beforeVersion = await desktopVersionAt(before);
+                              const headVersion = await desktopVersionAt(context.sha);
+                              shouldPackage = beforeVersion !== headVersion;
+                              const comparison = await github.rest.repos.compareCommitsWithBasehead({
+                                  owner: context.repo.owner,
+                                  repo: context.repo.repo,
+                                  basehead: `${before}...${context.sha}`,
+                              });
+                              const files = comparison.data.files ?? [];
+                              const touchedDesktopPackage = files.some((file) => {
+                                  return file.filename === 'apps/desktop/package.json';
+                              });
+                              core.info(`Desktop package changed: ${touchedDesktopPackage}`);
+                              core.info(`Desktop version: ${beforeVersion} -> ${headVersion}`);
+                          }
                       } else if (eventName === 'push' && ref.startsWith('refs/tags/')) {
                           releaseChannel = ref.replace('refs/tags/', '');
                           retentionDays = '90';
@@ -92,21 +129,25 @@ jobs:
                       core.info(`Release channel: ${releaseChannel}`);
                       core.info(`Retention days: ${retentionDays}`);
                       core.info(`Package matrix: ${JSON.stringify(matrix)}`);
+                      core.info(`Should package: ${shouldPackage}`);
                       core.setOutput('matrix', JSON.stringify(matrix));
                       core.setOutput('release_channel', releaseChannel);
                       core.setOutput('retention_days', retentionDays);
+                      core.setOutput('should_package', String(shouldPackage));
 
     ci:
         uses: ./.github/workflows/ci.yml
 
     package:
         needs: [ prepare, ci ]
+        if: needs.prepare.outputs.should_package == 'true'
         runs-on: ${{ matrix.os }}
         strategy:
             fail-fast: false
             matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
         env:
             GCLOUD_PROJECT: demo-local
+            RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
             RELEASE_CHANNEL: ${{ needs.prepare.outputs.release_channel }}
         steps:
             - uses: actions/checkout@v6
@@ -128,6 +169,7 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install -y xvfb libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2t64 libgtk-3-0 libsecret-1-0 libnotify4 libxss1 libxtst6 xdg-utils
             - run: pnpm install --frozen-lockfile
+            - run: pnpm test:release-version
             - run: pnpm package
             - name: Resolve package names
               id: package_names
@@ -175,13 +217,29 @@ jobs:
     publish-latest:
         needs: [ prepare, package ]
         runs-on: ubuntu-latest
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.prepare.outputs.should_package == 'true'
         permissions:
             contents: write
         steps:
+            - uses: actions/checkout@v6
+            - uses: pnpm/action-setup@v5
+              with:
+                  version: 10.33.2
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: 24
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile
             - uses: actions/download-artifact@v7
               with:
                   path: artifacts
+            - name: Write release manifest
+              run: pnpm release:manifest
+              env:
+                  RELEASE_ARTIFACTS_DIR: artifacts
+                  RELEASE_CHANNEL: latest
+                  RELEASE_MANIFEST_FILE: artifacts/release-manifest.json
+                  RELEASE_URL: https://github.com/${{ github.repository }}/releases/tag/latest
             - name: Publish rolling prerelease
               env:
                   GH_TOKEN: ${{ github.token }}
@@ -214,13 +272,42 @@ jobs:
         permissions:
             contents: write
         steps:
+            - uses: actions/checkout@v6
+            - uses: pnpm/action-setup@v5
+              with:
+                  version: 10.33.2
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: 24
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile
             - uses: actions/download-artifact@v7
               with:
                   path: artifacts
+            - name: Write release manifest
+              run: pnpm release:manifest
+              env:
+                  RELEASE_ARTIFACTS_DIR: artifacts
+                  RELEASE_CHANNEL: ${{ github.ref_name }}
+                  RELEASE_MANIFEST_FILE: artifacts/release-manifest.json
+                  RELEASE_TAG: ${{ github.ref_name }}
+                  RELEASE_URL: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+            - name: Write package manager manifests
+              run: pnpm package-managers:manifests
+              env:
+                  PACKAGE_MANAGER_MANIFEST_DIR: package-manager-manifests
+                  RELEASE_MANIFEST_FILE: artifacts/release-manifest.json
+                  RELEASE_TAG: ${{ github.ref_name }}
+            - uses: actions/upload-artifact@v7
+              with:
+                  name: package-manager-manifests-${{ github.ref_name }}
+                  path: package-manager-manifests
+                  if-no-files-found: error
+                  retention-days: 90
             - uses: softprops/action-gh-release@v3
               with:
                   draft: false
-                  prerelease: true
+                  prerelease: false
                   body: |
-                      Unsigned development build. OS warning prompts are expected. Verify downloads with the matching SHA256SUMS asset.
+                      Unsigned Firebase Desk build. OS warning prompts are expected. Verify downloads with the matching SHA256SUMS asset.
                   files: artifacts/**/*

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Safety note: binaries are published as unsigned development builds with SHA-256 
 - [docs/design-system.md](docs/design-system.md)
 - [docs/project-structure.md](docs/project-structure.md)
 - [docs/release-checklist.md](docs/release-checklist.md)
+- [docs/package-managers.md](docs/package-managers.md)
 - [docs/testing-ci.md](docs/testing-ci.md)
 
 ## Local Scripts ↔ GitHub Actions
@@ -59,23 +60,27 @@ The Docker wrapper runs the Ubuntu image as `linux/amd64` and grants the Chromiu
 
 ## Release Workflow
 
-Firebase Desk publishes unsigned development binaries with SHA-256 checksums. We do not plan to sign binaries; package-manager distribution can come later.
+Firebase Desk publishes unsigned binaries with SHA-256 checksums. We do not plan to sign binaries; package-manager distribution starts with self-owned Homebrew and Scoop manifests.
 
 | Event           | Output                                                                                                                   |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | PR to `main`    | CI, package Linux; package macOS/Windows when `package-all` or package paths change; upload temporary workflow artifacts |
-| Merge to `main` | CI, package macOS/Windows/Linux, publish/update prerelease `latest`                                                      |
-| Tag `v*.*.*`    | CI, package macOS/Windows/Linux, publish versioned prerelease                                                            |
+| Merge to `main` | CI, package macOS/Windows/Linux, publish/update prerelease `latest` when the desktop version changed                     |
+| Tag `v*.*.*`    | CI, package macOS/Windows/Linux, publish a stable versioned release                                                      |
 | Manual dispatch | Ad-hoc package smoke run with temporary workflow artifacts                                                               |
 
-Use PR artifacts to block broken packaging before merge. Use GitHub Release assets from `latest` and version tags as the long-lived download links. The rolling `latest` tag is created once and kept stable; the release assets and notes are updated on each merge.
+Use PR artifacts to block broken packaging before merge. Use GitHub Release assets from `latest` and version tags as the long-lived download links. The rolling `latest` tag is created once and kept stable; the release assets and notes are updated only when the desktop package version changes.
+
+Pull requests to `main` must change `apps/desktop/package.json` version unless the title includes `[skip release]`. Version tags must match the desktop package version, for example `v0.1.0` requires `apps/desktop/package.json` version `0.1.0`.
 
 ## Downloads
 
 - Rolling dev build: <https://github.com/viniciusrmcarneiro/firebase-desk/releases/tag/latest>
-- Versioned prereleases: <https://github.com/viniciusrmcarneiro/firebase-desk/releases>
+- Versioned releases: <https://github.com/viniciusrmcarneiro/firebase-desk/releases>
 
 Artifact names include channel/version, OS, architecture, and target extension. PR and manual-dispatch artifacts are temporary workflow artifacts, not release assets. Each package artifact set includes a matching `SHA256SUMS*.txt` file.
+
+Versioned releases also include `release-manifest.json`. Tag workflows generate Homebrew cask and Scoop manifests as workflow artifacts for self-owned package manager distribution.
 
 ## Checksums
 
@@ -93,4 +98,4 @@ Run that command in the directory containing the downloaded binary and matching 
 - Windows: SmartScreen may warn on the installer or zip app. For local smoke testing, use `More info > Run anyway`.
 - Linux: AppImage builds may need `chmod +x Firebase\ Desk-*.AppImage`; `.deb` builds can be installed with `sudo apt install ./Firebase\ Desk-*.deb`.
 
-Signing, notarization, and Windows code-signing are intentionally out of scope. Package-manager distribution is a later improvement. See [docs/release-checklist.md](docs/release-checklist.md).
+Signing, notarization, and Windows code-signing are intentionally out of scope. Package managers provide checksums and update paths, not signing. See [docs/release-checklist.md](docs/release-checklist.md).

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebase-desk/desktop",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "license": "MIT",
   "description": "Firebase Desk Electron application.",

--- a/apps/desktop/src/main/ipc/app-handlers.ts
+++ b/apps/desktop/src/main/ipc/app-handlers.ts
@@ -20,6 +20,7 @@ export function createAppHandlers(
     }),
     'app.config': async () => ({
       ...await resolveDataMode(deps.settingsRepository),
+      appVersion: deps.appVersion,
       dataDirectory: deps.dataDirectory,
     }),
     'app.openDataDirectory': async () => {

--- a/apps/desktop/src/main/ipc/registry.test.ts
+++ b/apps/desktop/src/main/ipc/registry.test.ts
@@ -57,6 +57,10 @@ describe('IPC handler registry', () => {
         appVersion: '0.0.0',
         pong: 'pong',
       });
+    await expect(registered.get('app.config')?.({}, {})).resolves.toMatchObject({
+      appVersion: '0.0.0',
+      dataDirectory: '/tmp/firebase-desk-test',
+    });
     stderrWrite.mockRestore();
   });
 });

--- a/apps/desktop/src/renderer/app/App.test.tsx
+++ b/apps/desktop/src/renderer/app/App.test.tsx
@@ -14,8 +14,13 @@ vi.mock('@firebase-desk/product-ui', () => ({
   AppearanceProvider: ({ children }: { readonly children: ReactNode; }) => <>{children}</>,
 }));
 
+const appShellProps = vi.hoisted(() => vi.fn());
+
 vi.mock('./AppShell.tsx', () => ({
-  AppShell: () => <div data-testid='app-shell' />,
+  AppShell: (props: { readonly appVersion?: string | undefined; }) => {
+    appShellProps(props);
+    return <div data-testid='app-shell' />;
+  },
 }));
 
 vi.mock('./RepositoryProvider.tsx', () => ({
@@ -28,6 +33,7 @@ vi.mock('./RepositoryProvider.tsx', () => ({
 describe('desktop App', () => {
   beforeEach(() => {
     settingsLoad.mockReset();
+    appShellProps.mockReset();
     vi.stubGlobal('firebaseDesk', undefined);
   });
 
@@ -46,13 +52,14 @@ describe('desktop App', () => {
     render(<App />);
 
     await waitFor(() => expect(screen.getByTestId('app-shell')).toBeTruthy());
+    expect(appShellProps).toHaveBeenCalledWith(expect.objectContaining({ appVersion: '0.0.0' }));
     expect(screen.queryByLabelText('Loading Firebase Desk')).toBeNull();
   });
 
   it('shows a retryable boot failure when config load fails', async () => {
     const getConfig = vi.fn()
       .mockRejectedValueOnce(new Error('config unavailable'))
-      .mockResolvedValue({ dataMode: 'mock' });
+      .mockResolvedValue({ appVersion: '0.1.0', dataMode: 'mock' });
     settingsLoad.mockResolvedValue(settingsSnapshot());
     vi.stubGlobal('firebaseDesk', { app: { getConfig } });
 

--- a/apps/desktop/src/renderer/app/App.test.tsx
+++ b/apps/desktop/src/renderer/app/App.test.tsx
@@ -39,7 +39,9 @@ describe('desktop App', () => {
     settingsLoad.mockReset();
     createRepositories.mockReset();
     appShellProps.mockReset();
-    vi.stubGlobal('firebaseDesk', undefined);
+    vi.stubGlobal('firebaseDesk', {
+      app: { getConfig: vi.fn().mockResolvedValue({ appVersion: '0.1.0', dataMode: 'mock' }) },
+    });
   });
 
   it('shows the splash while settings load', () => {
@@ -57,7 +59,7 @@ describe('desktop App', () => {
     render(<App />);
 
     await waitFor(() => expect(screen.getByTestId('app-shell')).toBeTruthy());
-    expect(appShellProps).toHaveBeenCalledWith(expect.objectContaining({ appVersion: '0.0.1' }));
+    expect(appShellProps).toHaveBeenCalledWith(expect.objectContaining({ appVersion: '0.1.0' }));
     expect(screen.queryByLabelText('Loading Firebase Desk')).toBeNull();
   });
 
@@ -101,6 +103,18 @@ describe('desktop App', () => {
 
     await waitFor(() => expect(screen.getByTestId('app-shell')).toBeTruthy());
     expect(getConfig).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows a retryable boot failure when preload app API is unavailable', async () => {
+    settingsLoad.mockResolvedValue(settingsSnapshot());
+    vi.stubGlobal('firebaseDesk', undefined);
+
+    render(<App />);
+
+    await waitFor(() =>
+      expect(screen.getByLabelText('Firebase Desk failed to start')).toBeTruthy()
+    );
+    expect(screen.getByText('Firebase Desk preload app API is unavailable.')).toBeTruthy();
   });
 
   it('shows a retryable boot failure when settings load fails', async () => {

--- a/apps/desktop/src/renderer/app/App.test.tsx
+++ b/apps/desktop/src/renderer/app/App.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@firebase-desk/product-ui', () => ({
 const appShellProps = vi.hoisted(() => vi.fn());
 
 vi.mock('./AppShell.tsx', () => ({
-  AppShell: (props: { readonly appVersion?: string | undefined; }) => {
+  AppShell: (props: { readonly appVersion: string; }) => {
     appShellProps(props);
     return <div data-testid='app-shell' />;
   },
@@ -57,7 +57,7 @@ describe('desktop App', () => {
     render(<App />);
 
     await waitFor(() => expect(screen.getByTestId('app-shell')).toBeTruthy());
-    expect(appShellProps).toHaveBeenCalledWith(expect.objectContaining({ appVersion: '0.0.0' }));
+    expect(appShellProps).toHaveBeenCalledWith(expect.objectContaining({ appVersion: '0.0.1' }));
     expect(screen.queryByLabelText('Loading Firebase Desk')).toBeNull();
   });
 

--- a/apps/desktop/src/renderer/app/App.test.tsx
+++ b/apps/desktop/src/renderer/app/App.test.tsx
@@ -1,10 +1,11 @@
 import type { SettingsSnapshot } from '@firebase-desk/repo-contracts';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { App } from './App.tsx';
 
 const settingsLoad = vi.hoisted(() => vi.fn());
+const createRepositories = vi.hoisted(() => vi.fn());
 
 vi.mock('@firebase-desk/hotkeys', () => ({
   HotkeysProvider: ({ children }: { readonly children: ReactNode; }) => <>{children}</>,
@@ -24,15 +25,19 @@ vi.mock('./AppShell.tsx', () => ({
 }));
 
 vi.mock('./RepositoryProvider.tsx', () => ({
-  createRepositories: () => ({
-    settings: { load: settingsLoad },
-  }),
+  createRepositories: (options: unknown) => {
+    createRepositories(options);
+    return {
+      settings: { load: settingsLoad },
+    };
+  },
   RepositoryProvider: ({ children }: { readonly children: ReactNode; }) => <>{children}</>,
 }));
 
 describe('desktop App', () => {
   beforeEach(() => {
     settingsLoad.mockReset();
+    createRepositories.mockReset();
     appShellProps.mockReset();
     vi.stubGlobal('firebaseDesk', undefined);
   });
@@ -54,6 +59,28 @@ describe('desktop App', () => {
     await waitFor(() => expect(screen.getByTestId('app-shell')).toBeTruthy());
     expect(appShellProps).toHaveBeenCalledWith(expect.objectContaining({ appVersion: '0.0.0' }));
     expect(screen.queryByLabelText('Loading Firebase Desk')).toBeNull();
+  });
+
+  it('keeps the app version when data mode changes', async () => {
+    settingsLoad.mockResolvedValue(settingsSnapshot());
+    vi.stubGlobal('firebaseDesk', {
+      app: { getConfig: vi.fn().mockResolvedValue({ appVersion: '0.1.0', dataMode: 'mock' }) },
+    });
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByTestId('app-shell')).toBeTruthy());
+    const options = createRepositories.mock.calls.at(-1)?.[0] as {
+      readonly onDataModeChange: (dataMode: 'live') => void;
+    };
+
+    await act(async () => options.onDataModeChange('live'));
+
+    await waitFor(() =>
+      expect(appShellProps).toHaveBeenLastCalledWith(
+        expect.objectContaining({ appVersion: '0.1.0' }),
+      )
+    );
   });
 
   it('shows a retryable boot failure when config load fails', async () => {

--- a/apps/desktop/src/renderer/app/App.tsx
+++ b/apps/desktop/src/renderer/app/App.tsx
@@ -8,6 +8,11 @@ import { AppShell } from './AppShell.tsx';
 import { RenderErrorBoundary } from './RenderErrorBoundary.tsx';
 import { createRepositories, RepositoryProvider } from './RepositoryProvider.tsx';
 
+interface AppConfig {
+  readonly appVersion: string;
+  readonly dataMode: DataMode;
+}
+
 function SplashScreen() {
   return (
     <section
@@ -58,18 +63,21 @@ function BootFailureScreen(
 
 export function App() {
   const [dataMode, setDataMode] = useState<DataMode | null>(null);
+  const [appVersion, setAppVersion] = useState<string | null>(null);
   const [snapshot, setSnapshot] = useState<SettingsSnapshot | null>(null);
   const [bootAttempt, setBootAttempt] = useState(0);
   const [bootError, setBootError] = useState<string | null>(null);
 
   const handleDataModeChange = useCallback((nextDataMode: DataMode) => {
     setBootError(null);
+    setAppVersion(null);
     setSnapshot(null);
     setDataMode(nextDataMode);
   }, []);
 
   const retryBoot = useCallback(() => {
     setBootError(null);
+    setAppVersion(null);
     setDataMode(null);
     setSnapshot(null);
     setBootAttempt((attempt) => attempt + 1);
@@ -96,8 +104,11 @@ export function App() {
   useEffect(() => {
     let cancelled = false;
     setBootError(null);
-    loadInitialDataMode().then((config) => {
-      if (!cancelled) setDataMode(config.dataMode);
+    loadAppConfig().then((config) => {
+      if (!cancelled) {
+        setAppVersion(config.appVersion);
+        setDataMode(config.dataMode);
+      }
     }).catch((error) => {
       if (!cancelled) {
         setBootError(messageFromError(error, 'Could not load app configuration.'));
@@ -140,6 +151,7 @@ export function App() {
           >
             <RenderErrorBoundary label='Firebase Desk' resetKey={dataMode ?? 'mock'}>
               <AppShell
+                appVersion={appVersion ?? undefined}
                 dataMode={dataMode ?? 'mock'}
                 initialSidebarWidth={snapshot.sidebarWidth}
               />
@@ -155,9 +167,9 @@ function messageFromError(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
 
-async function loadInitialDataMode(): Promise<{ readonly dataMode: DataMode; }> {
+async function loadAppConfig(): Promise<AppConfig> {
   if (typeof window !== 'undefined' && window.firebaseDesk?.app?.getConfig) {
     return await window.firebaseDesk.app.getConfig();
   }
-  return { dataMode: 'mock' };
+  return { appVersion: '0.0.0', dataMode: 'mock' };
 }

--- a/apps/desktop/src/renderer/app/App.tsx
+++ b/apps/desktop/src/renderer/app/App.tsx
@@ -70,7 +70,6 @@ export function App() {
 
   const handleDataModeChange = useCallback((nextDataMode: DataMode) => {
     setBootError(null);
-    setAppVersion(null);
     setSnapshot(null);
     setDataMode(nextDataMode);
   }, []);

--- a/apps/desktop/src/renderer/app/App.tsx
+++ b/apps/desktop/src/renderer/app/App.tsx
@@ -170,5 +170,5 @@ async function loadAppConfig(): Promise<AppConfig> {
   if (typeof window !== 'undefined' && window.firebaseDesk?.app?.getConfig) {
     return await window.firebaseDesk.app.getConfig();
   }
-  return { appVersion: '0.0.1', dataMode: 'mock' };
+  throw new Error('Firebase Desk preload app API is unavailable.');
 }

--- a/apps/desktop/src/renderer/app/App.tsx
+++ b/apps/desktop/src/renderer/app/App.tsx
@@ -135,7 +135,7 @@ export function App() {
   }, [repositories]);
 
   if (bootError) return <BootFailureScreen message={bootError} onRetry={retryBoot} />;
-  if (!repositories || !snapshot) return <SplashScreen />;
+  if (!repositories || !snapshot || appVersion === null) return <SplashScreen />;
 
   return (
     <RepositoryProvider repositories={repositories}>
@@ -150,7 +150,7 @@ export function App() {
           >
             <RenderErrorBoundary label='Firebase Desk' resetKey={dataMode ?? 'mock'}>
               <AppShell
-                appVersion={appVersion ?? undefined}
+                appVersion={appVersion}
                 dataMode={dataMode ?? 'mock'}
                 initialSidebarWidth={snapshot.sidebarWidth}
               />
@@ -170,5 +170,5 @@ async function loadAppConfig(): Promise<AppConfig> {
   if (typeof window !== 'undefined' && window.firebaseDesk?.app?.getConfig) {
     return await window.firebaseDesk.app.getConfig();
   }
-  return { appVersion: '0.0.0', dataMode: 'mock' };
+  return { appVersion: '0.0.1', dataMode: 'mock' };
 }

--- a/apps/desktop/src/renderer/app/AppDialogs.tsx
+++ b/apps/desktop/src/renderer/app/AppDialogs.tsx
@@ -15,6 +15,7 @@ import type { RepositorySet } from './RepositoryProvider.tsx';
 
 interface AppDialogsProps {
   readonly addProjectOpen: boolean;
+  readonly appVersion?: string | undefined;
   readonly canOpenDataDirectory: boolean;
   readonly credentialWarning: string | null;
   readonly dataDirectoryPath: string | null | undefined;
@@ -42,6 +43,7 @@ interface AppDialogsProps {
 export function AppDialogs(
   {
     addProjectOpen,
+    appVersion,
     canOpenDataDirectory,
     credentialWarning,
     dataDirectoryPath,
@@ -66,6 +68,7 @@ export function AppDialogs(
   return (
     <>
       <SettingsDialog
+        appVersion={appVersion}
         {...(canOpenDataDirectory
           ? {
             dataDirectoryPath,

--- a/apps/desktop/src/renderer/app/AppDialogs.tsx
+++ b/apps/desktop/src/renderer/app/AppDialogs.tsx
@@ -15,7 +15,7 @@ import type { RepositorySet } from './RepositoryProvider.tsx';
 
 interface AppDialogsProps {
   readonly addProjectOpen: boolean;
-  readonly appVersion?: string | undefined;
+  readonly appVersion: string;
   readonly canOpenDataDirectory: boolean;
   readonly credentialWarning: string | null;
   readonly dataDirectoryPath: string | null | undefined;

--- a/apps/desktop/src/renderer/app/AppShell.test.tsx
+++ b/apps/desktop/src/renderer/app/AppShell.test.tsx
@@ -127,7 +127,7 @@ function renderShell(
     <RepositoryProvider repositories={repositories}>
       <HotkeysProvider settings={repositories.settings}>
         <AppearanceProvider settings={repositories.settings}>
-          <AppShell dataMode={dataMode} />
+          <AppShell appVersion='0.1.0' dataMode={dataMode} />
         </AppearanceProvider>
       </HotkeysProvider>
     </RepositoryProvider>,

--- a/apps/desktop/src/renderer/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/app/AppShell.tsx
@@ -10,7 +10,7 @@ import { DEFAULT_SIDEBAR_WIDTH, MIN_WORKSPACE_WIDTH } from './workspaceModel.ts'
 import { WorkspaceTabView } from './WorkspaceTabView.tsx';
 
 export interface AppShellProps {
-  readonly appVersion?: string | undefined;
+  readonly appVersion: string;
   readonly activityStore?: ActivityStore | undefined;
   readonly dataMode?: 'live' | 'mock';
   readonly initialSidebarWidth?: number;

--- a/apps/desktop/src/renderer/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/app/AppShell.tsx
@@ -10,6 +10,7 @@ import { DEFAULT_SIDEBAR_WIDTH, MIN_WORKSPACE_WIDTH } from './workspaceModel.ts'
 import { WorkspaceTabView } from './WorkspaceTabView.tsx';
 
 export interface AppShellProps {
+  readonly appVersion?: string | undefined;
   readonly activityStore?: ActivityStore | undefined;
   readonly dataMode?: 'live' | 'mock';
   readonly initialSidebarWidth?: number;
@@ -18,11 +19,17 @@ export interface AppShellProps {
 export function AppShell(
   {
     activityStore,
+    appVersion,
     dataMode = 'mock',
     initialSidebarWidth = DEFAULT_SIDEBAR_WIDTH,
   }: AppShellProps,
 ) {
-  const controller = useAppShellController({ activityStore, dataMode, initialSidebarWidth });
+  const controller = useAppShellController({
+    activityStore,
+    appVersion,
+    dataMode,
+    initialSidebarWidth,
+  });
   const activeView = controller.tabView ? <WorkspaceTabView {...controller.tabView} /> : null;
 
   return (

--- a/apps/desktop/src/renderer/app/appShellOrchestrator.test.ts
+++ b/apps/desktop/src/renderer/app/appShellOrchestrator.test.ts
@@ -379,6 +379,7 @@ function createInput(
     activeTab: tab,
     addProjectOpen: false,
     appearance: { mode: 'system', resolvedTheme: 'dark' },
+    appVersion: '0.1.0',
     authTab: authTabFacade,
     canOpenDataDirectory: true,
     closeWorkspaceTabs: closeWorkspaceTabsCommand,

--- a/apps/desktop/src/renderer/app/appShellOrchestrator.ts
+++ b/apps/desktop/src/renderer/app/appShellOrchestrator.ts
@@ -56,7 +56,7 @@ export interface AppShellController {
   readonly commands: ReadonlyArray<CommandPaletteItem>;
   readonly dialogs: {
     readonly addProjectOpen: boolean;
-    readonly appVersion?: string | undefined;
+    readonly appVersion: string;
     readonly canOpenDataDirectory: boolean;
     readonly credentialWarning: string | null;
     readonly dataDirectoryPath: string | null | undefined;
@@ -204,7 +204,7 @@ export interface AppShellOrchestratorInput {
     readonly mode: 'dark' | 'light' | 'system';
     readonly resolvedTheme: 'dark' | 'light';
   };
-  readonly appVersion?: string | undefined;
+  readonly appVersion: string;
   readonly authTab: AppShellAuthFacade;
   readonly canOpenDataDirectory: boolean;
   readonly closeWorkspaceTabs: (

--- a/apps/desktop/src/renderer/app/appShellOrchestrator.ts
+++ b/apps/desktop/src/renderer/app/appShellOrchestrator.ts
@@ -56,6 +56,7 @@ export interface AppShellController {
   readonly commands: ReadonlyArray<CommandPaletteItem>;
   readonly dialogs: {
     readonly addProjectOpen: boolean;
+    readonly appVersion?: string | undefined;
     readonly canOpenDataDirectory: boolean;
     readonly credentialWarning: string | null;
     readonly dataDirectoryPath: string | null | undefined;
@@ -203,6 +204,7 @@ export interface AppShellOrchestratorInput {
     readonly mode: 'dark' | 'light' | 'system';
     readonly resolvedTheme: 'dark' | 'light';
   };
+  readonly appVersion?: string | undefined;
   readonly authTab: AppShellAuthFacade;
   readonly canOpenDataDirectory: boolean;
   readonly closeWorkspaceTabs: (
@@ -949,6 +951,7 @@ export function createAppShellController(
     commands,
     dialogs: {
       addProjectOpen: input.addProjectOpen,
+      appVersion: input.appVersion,
       canOpenDataDirectory: input.canOpenDataDirectory,
       credentialWarning: input.credentialWarning,
       dataDirectoryPath: input.settings.dataDirectoryPath,

--- a/apps/desktop/src/renderer/app/hooks/useAppShellController.integration.test.tsx
+++ b/apps/desktop/src/renderer/app/hooks/useAppShellController.integration.test.tsx
@@ -284,7 +284,7 @@ function renderController(
     })),
   );
   const activityStore = activityState ? createActivityStore(activityState) : undefined;
-  return renderHook(() => useAppShellController({ activityStore, dataMode }), {
+  return renderHook(() => useAppShellController({ activityStore, appVersion: '0.1.0', dataMode }), {
     wrapper: ({ children }: { readonly children: ReactNode; }) => (
       <MaybeStrictMode strictMode={strictMode}>
         <RepositoryProvider repositories={repositories}>

--- a/apps/desktop/src/renderer/app/hooks/useAppShellController.test.tsx
+++ b/apps/desktop/src/renderer/app/hooks/useAppShellController.test.tsx
@@ -122,7 +122,9 @@ describe('useAppShellController', () => {
     });
     setupMocks(scenario);
 
-    const { result } = renderHook(() => useAppShellController({ initialSidebarWidth: 999 }));
+    const { result } = renderHook(() =>
+      useAppShellController({ appVersion: '0.1.0', initialSidebarWidth: 999 })
+    );
 
     const input = expectControllerInput();
     expect(result.current).toBe(scenario.controller);
@@ -155,7 +157,7 @@ describe('useAppShellController', () => {
     });
     setupMocks(scenario);
 
-    renderHook(() => useAppShellController());
+    renderHook(() => useAppShellController({ appVersion: '0.1.0' }));
 
     expect(mocks.useFirestoreTabState).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -204,7 +206,7 @@ describe('useAppShellController', () => {
     });
     setupMocks(scenario);
 
-    renderHook(() => useAppShellController());
+    renderHook(() => useAppShellController({ appVersion: '0.1.0' }));
     const input = expectControllerInput();
 
     input.layout.onSidebarResize(10);
@@ -223,7 +225,7 @@ describe('useAppShellController', () => {
     const scenario = createScenario();
     setupMocks(scenario);
 
-    renderHook(() => useAppShellController({ dataMode: 'live' }));
+    renderHook(() => useAppShellController({ appVersion: '0.1.0', dataMode: 'live' }));
 
     expect(mocks.useSettingsController).toHaveBeenCalledWith(
       expect.objectContaining({ dataDirectoryApi: desktopAppApi }),
@@ -246,7 +248,7 @@ describe('useAppShellController', () => {
     });
     setupMocks(scenario);
 
-    renderHook(() => useAppShellController());
+    renderHook(() => useAppShellController({ appVersion: '0.1.0' }));
 
     await waitFor(() => {
       expect(mocks.createAppShellController).toHaveBeenLastCalledWith(

--- a/apps/desktop/src/renderer/app/hooks/useAppShellController.ts
+++ b/apps/desktop/src/renderer/app/hooks/useAppShellController.ts
@@ -29,6 +29,7 @@ import { useProjects } from './useProjects.ts';
 import { useWorkspaceTree } from './useWorkspaceTree.ts';
 
 export interface UseAppShellControllerInput {
+  readonly appVersion?: string | undefined;
   readonly activityStore?: ActivityStore | undefined;
   readonly dataMode?: 'live' | 'mock';
   readonly initialSidebarWidth?: number;
@@ -37,6 +38,7 @@ export interface UseAppShellControllerInput {
 export function useAppShellController(
   {
     activityStore,
+    appVersion,
     dataMode = 'mock',
     initialSidebarWidth = DEFAULT_SIDEBAR_WIDTH,
   }: UseAppShellControllerInput = {},
@@ -208,6 +210,7 @@ export function useAppShellController(
       toggle: activity.toggle,
     },
     addProjectOpen,
+    appVersion,
     appearance: {
       mode: appearance.mode,
       resolvedTheme: appearance.resolvedTheme,

--- a/apps/desktop/src/renderer/app/hooks/useAppShellController.ts
+++ b/apps/desktop/src/renderer/app/hooks/useAppShellController.ts
@@ -29,7 +29,7 @@ import { useProjects } from './useProjects.ts';
 import { useWorkspaceTree } from './useWorkspaceTree.ts';
 
 export interface UseAppShellControllerInput {
-  readonly appVersion?: string | undefined;
+  readonly appVersion: string;
   readonly activityStore?: ActivityStore | undefined;
   readonly dataMode?: 'live' | 'mock';
   readonly initialSidebarWidth?: number;
@@ -41,7 +41,7 @@ export function useAppShellController(
     appVersion,
     dataMode = 'mock',
     initialSidebarWidth = DEFAULT_SIDEBAR_WIDTH,
-  }: UseAppShellControllerInput = {},
+  }: UseAppShellControllerInput,
 ): AppShellController {
   const appearance = useAppearance();
   const repositories = useRepositories();

--- a/apps/storybook/src/product-ui.stories.tsx
+++ b/apps/storybook/src/product-ui.stories.tsx
@@ -92,6 +92,7 @@ function SettingsDialogStory() {
   const [density, setDensity] = useState<DensityName>('compact');
   return (
     <SettingsDialog
+      appVersion='0.1.0'
       density={density}
       open
       onDensityChange={setDensity}

--- a/docs/package-managers.md
+++ b/docs/package-managers.md
@@ -1,0 +1,27 @@
+# Package Managers
+
+Firebase Desk starts package-manager distribution with self-owned manifests generated from stable version tags.
+
+## Channels
+
+- GitHub Releases remain the source of binaries and checksums.
+- `latest` is a rolling prerelease for smoke testing.
+- `vX.Y.Z` tags are stable releases for package managers.
+- Generated package-manager manifests are workflow artifacts on tag releases.
+
+## First Targets
+
+- Homebrew tap: `viniciusrmcarneiro/homebrew-tap`.
+- Scoop bucket: `viniciusrmcarneiro/scoop-bucket`.
+- winget comes after one successful stable release.
+
+## Release Requirements
+
+- Root and desktop package versions must match.
+- PRs to `main` must bump `apps/desktop/package.json` unless the title includes `[skip release]`.
+- Tag `vX.Y.Z` must match desktop version `X.Y.Z`.
+- Each release must include package assets, `SHA256SUMS*.txt`, and `release-manifest.json`.
+
+## Unsigned Builds
+
+Package managers provide checksums and easier updates, not code signing. macOS Gatekeeper and Windows SmartScreen warnings are still expected until signing policy changes.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,11 +1,13 @@
 # Release Checklist
 
-Use this for unsigned development releases. Binaries are published as prereleases with SHA-256 checksums. Signing/notarization/code-signing are intentionally out of scope; package-manager distribution can come later.
+Use this for unsigned releases. `latest` is a rolling prerelease. Version tags are stable releases with SHA-256 checksums. Signing/notarization/code-signing are intentionally out of scope.
 
 ## Before Merge
 
 - [ ] `ci.yml` green.
 - [ ] `e2e.yml` green.
+- [ ] `release-gate.yml` green.
+- [ ] PR changes `apps/desktop/package.json` version or title contains `[skip release]`.
 - [ ] `release.yml` PR package job green.
 - [ ] PR package artifacts uploaded with expected channel, OS, architecture, and target names.
 - [ ] PR package artifacts include matching `SHA256SUMS*.txt` files.
@@ -16,6 +18,7 @@ Use this for unsigned development releases. Binaries are published as prerelease
 ## Rolling Main Build
 
 - [ ] Merge to `main`.
+- [ ] Confirm merged PR changed `apps/desktop/package.json`; otherwise no rolling release is expected.
 - [ ] `release.yml` package job green on macOS, Windows, and Linux.
 - [ ] `latest` tag exists.
 - [ ] `latest` prerelease created or updated.
@@ -27,12 +30,12 @@ Use this for unsigned development releases. Binaries are published as prerelease
 - [ ] Install/open Windows asset.
 - [ ] Install/open Linux asset.
 
-## First Versioned Prerelease
+## First Versioned Release
 
 - [ ] Confirm `latest` artifacts open on each OS.
-- [ ] Update package versions if needed.
+- [ ] Update root and desktop package versions.
 - [ ] Create tag: `git tag v0.0.1 && git push origin v0.0.1`.
-- [ ] Confirm `release.yml` creates a published GitHub prerelease for `v0.0.1`.
+- [ ] Confirm `release.yml` creates a published GitHub release for `v0.0.1`.
 - [ ] Download each versioned asset.
 - [ ] Verify every downloaded asset against the matching `SHA256SUMS*.txt` file.
 - [ ] Install/open macOS asset.
@@ -40,11 +43,13 @@ Use this for unsigned development releases. Binaries are published as prerelease
 - [ ] Install/open Linux asset.
 - [ ] Confirm release notes mention unsigned binaries and checksum verification.
 - [ ] Confirm assets are publicly downloadable.
+- [ ] Confirm `release-manifest.json` is attached.
+- [ ] Confirm package manager manifest workflow artifact exists.
 
 ## Later Distribution
 
-- [ ] Homebrew cask.
+- [ ] Self-owned Homebrew tap cask.
+- [ ] Self-owned Scoop bucket manifest.
 - [ ] winget manifest.
-- [ ] Scoop manifest.
 - [ ] Linux package manager path, if demand justifies it.
 - [ ] Public download copy and support policy.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -33,7 +33,7 @@ Use this for unsigned releases. `latest` is a rolling prerelease. Version tags a
 ## First Versioned Release
 
 - [ ] Confirm `latest` artifacts open on each OS.
-- [ ] Update root and desktop package versions.
+- [ ] Confirm root and desktop package versions are `0.0.1`.
 - [ ] Create tag: `git tag v0.0.1 && git push origin v0.0.1`.
 - [ ] Confirm `release.yml` creates a published GitHub release for `v0.0.1`.
 - [ ] Download each versioned asset.

--- a/docs/testing-ci.md
+++ b/docs/testing-ci.md
@@ -17,7 +17,8 @@ This doc explains how testing runs in CI, release, and package validation. Test 
 
 - `ci.yml`: install (pnpm), run `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test:coverage`, publish the coverage summary, then `pnpm build`.
 - `e2e.yml`: install, build affected workspaces, start Firebase emulators, seed data, run `pnpm test:e2e`, upload traces/screenshots on failure.
-- `release.yml`: on PR, merge to `main`, tag, or ad-hoc dispatch, run CI checks and `pnpm package` for the desktop app. PRs always package Linux, and package macOS/Windows when the PR has the `package-all` label or touches package-sensitive paths (`apps/desktop/**`, `e2e/**`, release workflows, package scripts, or lockfile). Linux, macOS, and Windows all run the packaged smoke check against the built app. PR and ad-hoc runs upload temporary workflow artifacts with retention. Merges to `main` create or update the rolling published prerelease `latest` with release assets and SHA-256 checksums. Version tags create published prereleases with release assets and SHA-256 checksums.
+- `release-gate.yml`: on PRs to `main`, require `apps/desktop/package.json` to change unless the PR title includes `[skip release]`.
+- `release.yml`: on PR, merge to `main`, tag, or ad-hoc dispatch, run CI checks and `pnpm package` for the desktop app. PRs always package Linux, and package macOS/Windows when the PR has the `package-all` label or touches package-sensitive paths (`apps/desktop/**`, `e2e/**`, release workflows, package scripts, or lockfile). Linux, macOS, and Windows all run the packaged smoke check against the built app. PR and ad-hoc runs upload temporary workflow artifacts with retention. Merges to `main` create or update the rolling published prerelease `latest` only when the desktop package version changed. Version tags create stable releases with release assets, SHA-256 checksums, `release-manifest.json`, and package manager manifest artifacts.
 
 ### Required Scripts (root `package.json`, delegated via turbo/pnpm filters)
 
@@ -29,6 +30,7 @@ This doc explains how testing runs in CI, release, and package validation. Test 
 - `pnpm test`
 - `pnpm test:boundaries`
 - `pnpm test:desktop-packaging`
+- `pnpm test:release-version`
 - `pnpm test:coverage`
 - `pnpm test:e2e`
 - `pnpm build`
@@ -57,8 +59,10 @@ This doc explains how testing runs in CI, release, and package validation. Test 
 - Release workflow must exist before the first packaged build is considered done.
 - PR package outputs are workflow artifacts only, not GitHub Release assets.
 - PR and manual package artifacts use short retention; main and tag artifacts use longer retention.
-- Every merge to `main` updates the rolling published prerelease `latest`; keep its tag stable and update assets instead of deleting/recreating the release.
-- Version tags create separate published prereleases.
+- Merges to `main` with a desktop version change update the rolling published prerelease `latest`; keep its tag stable and update assets instead of deleting/recreating the release.
+- Merges to `main` without a desktop version change do not publish a rolling release.
+- Version tags create separate published stable releases.
+- Version tags must match `apps/desktop/package.json`.
 - Unsigned builds are published intentionally with SHA-256 checksums; binary signing is not planned.
-- Package-manager distribution is deferred until the direct release path is stable.
+- Package-manager distribution starts with self-owned Homebrew and Scoop manifests generated from versioned releases.
 - First release phase validates unsigned app warnings and install/open smoke on each OS before Firebase feature work continues.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-desk",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "description": "Firebase Desk monorepo root.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test": "turbo run test test:repo-invariants",
     "test:boundaries": "tsx scripts/check-package-boundaries.ts",
     "test:desktop-packaging": "tsx scripts/check-desktop-packaging-contract.ts",
-    "test:repo-invariants": "pnpm test:boundaries && pnpm test:desktop-packaging",
+    "test:release-version": "tsx scripts/check-release-version.ts",
+    "test:repo-invariants": "pnpm test:boundaries && pnpm test:desktop-packaging && pnpm test:release-version",
     "test:coverage": "turbo run test:coverage test:repo-invariants",
     "test:packaged": "pnpm --dir e2e test:packaged",
     "coverage:summary": "node scripts/coverage-summary.mjs",
@@ -32,7 +33,9 @@
     "storybook": "pnpm --filter @firebase-desk/storybook dev",
     "test:e2e": "pnpm --dir e2e test:e2e",
     "test:smoke": "pnpm --dir e2e test:withEmulators",
-    "package": "pnpm --filter @firebase-desk/desktop package"
+    "package": "pnpm --filter @firebase-desk/desktop package",
+    "release:manifest": "tsx scripts/write-release-manifest.ts",
+    "package-managers:manifests": "tsx scripts/write-package-manager-manifests.ts"
   },
   "devDependencies": {
     "@types/node": "24.12.2",

--- a/packages/ipc-schemas/src/channels.ts
+++ b/packages/ipc-schemas/src/channels.ts
@@ -66,7 +66,11 @@ export const IPC_CHANNELS = {
   },
   'app.config': {
     request: z.object({}),
-    response: z.object({ dataDirectory: z.string(), dataMode: DataModeSchema }),
+    response: z.object({
+      appVersion: z.string(),
+      dataDirectory: z.string(),
+      dataMode: DataModeSchema,
+    }),
   },
   'app.openDataDirectory': {
     request: z.object({}),

--- a/packages/product-ui/src/settings-dialog/SettingsDialog.test.tsx
+++ b/packages/product-ui/src/settings-dialog/SettingsDialog.test.tsx
@@ -19,7 +19,12 @@ describe('SettingsDialog', () => {
     const onSettingsSaved = vi.fn();
     render(
       <AppearanceProvider settings={settings}>
-        <SettingsDialog open onOpenChange={vi.fn()} onSettingsSaved={onSettingsSaved} />
+        <SettingsDialog
+          appVersion='0.1.0'
+          open
+          onOpenChange={vi.fn()}
+          onSettingsSaved={onSettingsSaved}
+        />
       </AppearanceProvider>,
     );
     fireEvent.click(screen.getByRole('button', { name: 'dark' }));
@@ -42,7 +47,7 @@ describe('SettingsDialog', () => {
     const onOpenChange = vi.fn();
     render(
       <AppearanceProvider settings={new MockSettingsRepository()}>
-        <SettingsDialog open onOpenChange={onOpenChange} />
+        <SettingsDialog appVersion='0.1.0' open onOpenChange={onOpenChange} />
       </AppearanceProvider>,
     );
 
@@ -61,7 +66,7 @@ describe('SettingsDialog', () => {
     );
     render(
       <AppearanceProvider settings={new MockSettingsRepository()}>
-        <SettingsDialog open onOpenChange={vi.fn()} />
+        <SettingsDialog appVersion='0.1.0' open onOpenChange={vi.fn()} />
       </AppearanceProvider>,
     );
 
@@ -81,6 +86,7 @@ describe('SettingsDialog', () => {
     render(
       <AppearanceProvider settings={new MockSettingsRepository()}>
         <SettingsDialog
+          appVersion='0.1.0'
           density='compact'
           open
           onDensityChange={onDensityChange}
@@ -105,7 +111,7 @@ describe('SettingsDialog', () => {
     const settings = new MockSettingsRepository();
     render(
       <AppearanceProvider settings={settings}>
-        <SettingsDialog open onOpenChange={vi.fn()} />
+        <SettingsDialog appVersion='0.1.0' open onOpenChange={vi.fn()} />
       </AppearanceProvider>,
     );
 
@@ -127,7 +133,12 @@ describe('SettingsDialog', () => {
     const onSettingsSaved = vi.fn();
     render(
       <AppearanceProvider settings={settings}>
-        <SettingsDialog open onOpenChange={vi.fn()} onSettingsSaved={onSettingsSaved} />
+        <SettingsDialog
+          appVersion='0.1.0'
+          open
+          onOpenChange={vi.fn()}
+          onSettingsSaved={onSettingsSaved}
+        />
       </AppearanceProvider>,
     );
 
@@ -159,7 +170,12 @@ describe('SettingsDialog', () => {
     const onSettingsSaved = vi.fn();
     render(
       <AppearanceProvider settings={settings}>
-        <SettingsDialog open onOpenChange={vi.fn()} onSettingsSaved={onSettingsSaved} />
+        <SettingsDialog
+          appVersion='0.1.0'
+          open
+          onOpenChange={vi.fn()}
+          onSettingsSaved={onSettingsSaved}
+        />
       </AppearanceProvider>,
     );
 
@@ -195,7 +211,7 @@ describe('SettingsDialog', () => {
 
     render(
       <AppearanceProvider settings={settings}>
-        <SettingsDialog open onOpenChange={vi.fn()} onSettingsSaved={vi.fn()} />
+        <SettingsDialog appVersion='0.1.0' open onOpenChange={vi.fn()} onSettingsSaved={vi.fn()} />
       </AppearanceProvider>,
     );
 
@@ -228,7 +244,12 @@ describe('SettingsDialog', () => {
     const onSettingsSaved = vi.fn();
     render(
       <AppearanceProvider settings={settings}>
-        <SettingsDialog open onOpenChange={vi.fn()} onSettingsSaved={onSettingsSaved} />
+        <SettingsDialog
+          appVersion='0.1.0'
+          open
+          onOpenChange={vi.fn()}
+          onSettingsSaved={onSettingsSaved}
+        />
       </AppearanceProvider>,
     );
 
@@ -276,7 +297,7 @@ describe('SettingsDialog', () => {
     });
     render(
       <AppearanceProvider settings={settings}>
-        <SettingsDialog open onOpenChange={vi.fn()} />
+        <SettingsDialog appVersion='0.1.0' open onOpenChange={vi.fn()} />
       </AppearanceProvider>,
     );
 
@@ -337,7 +358,7 @@ describe('SettingsDialog', () => {
     const settings = createLegacySettingsRepository();
     render(
       <AppearanceProvider settings={settings}>
-        <SettingsDialog open onOpenChange={vi.fn()} />
+        <SettingsDialog appVersion='0.1.0' open onOpenChange={vi.fn()} />
       </AppearanceProvider>,
     );
 
@@ -357,7 +378,7 @@ describe('SettingsDialog', () => {
     const settings = new MockSettingsRepository();
     const { rerender } = render(
       <AppearanceProvider settings={settings}>
-        <SettingsDialog open onOpenChange={vi.fn()} />
+        <SettingsDialog appVersion='0.1.0' open onOpenChange={vi.fn()} />
       </AppearanceProvider>,
     );
 
@@ -378,12 +399,12 @@ describe('SettingsDialog', () => {
 
     rerender(
       <AppearanceProvider settings={settings}>
-        <SettingsDialog open={false} onOpenChange={vi.fn()} />
+        <SettingsDialog appVersion='0.1.0' open={false} onOpenChange={vi.fn()} />
       </AppearanceProvider>,
     );
     rerender(
       <AppearanceProvider settings={settings}>
-        <SettingsDialog open onOpenChange={vi.fn()} />
+        <SettingsDialog appVersion='0.1.0' open onOpenChange={vi.fn()} />
       </AppearanceProvider>,
     );
 
@@ -407,7 +428,7 @@ describe('SettingsDialog', () => {
     vi.spyOn(settings, 'save').mockRejectedValueOnce(new Error('Could not rename settings file'));
     render(
       <AppearanceProvider settings={settings}>
-        <SettingsDialog open onOpenChange={vi.fn()} />
+        <SettingsDialog appVersion='0.1.0' open onOpenChange={vi.fn()} />
       </AppearanceProvider>,
     );
 
@@ -431,6 +452,7 @@ describe('SettingsDialog', () => {
     render(
       <AppearanceProvider settings={new MockSettingsRepository()}>
         <SettingsDialog
+          appVersion='0.1.0'
           dataDirectoryPath='/Users/vini/Library/Application Support/@firebase-desk/desktop'
           open
           onOpenChange={vi.fn()}
@@ -460,6 +482,7 @@ describe('SettingsDialog', () => {
     render(
       <AppearanceProvider settings={new MockSettingsRepository()}>
         <SettingsDialog
+          appVersion='0.1.0'
           dataDirectoryPath={null}
           open
           onOpenChange={vi.fn()}
@@ -485,6 +508,7 @@ describe('SettingsDialog', () => {
     render(
       <AppearanceProvider settings={new MockSettingsRepository()}>
         <SettingsDialog
+          appVersion='0.1.0'
           dataDirectoryPath='/tmp/firebase-desk'
           open
           onOpenChange={vi.fn()}
@@ -537,7 +561,7 @@ describe('SettingsDialog', () => {
     await settings.save({ dataMode: 'mock' });
     render(
       <AppearanceProvider settings={settings}>
-        <SettingsDialog open onOpenChange={vi.fn()} />
+        <SettingsDialog appVersion='0.1.0' open onOpenChange={vi.fn()} />
       </AppearanceProvider>,
     );
 

--- a/packages/product-ui/src/settings-dialog/SettingsDialog.test.tsx
+++ b/packages/product-ui/src/settings-dialog/SettingsDialog.test.tsx
@@ -313,7 +313,7 @@ describe('SettingsDialog', () => {
     vi.spyOn(settings, 'save').mockRejectedValueOnce(new Error('metadata locked'));
     render(
       <AppearanceProvider settings={settings}>
-        <SettingsDialog open onOpenChange={vi.fn()} />
+        <SettingsDialog appVersion='0.1.0' open onOpenChange={vi.fn()} />
       </AppearanceProvider>,
     );
 
@@ -511,7 +511,7 @@ describe('SettingsDialog', () => {
     await settings.save({ dataMode: 'live', sidebarWidth: 412, inspectorWidth: 388 });
     render(
       <AppearanceProvider settings={settings}>
-        <SettingsDialog open onOpenChange={vi.fn()} />
+        <SettingsDialog appVersion='0.1.0' open onOpenChange={vi.fn()} />
       </AppearanceProvider>,
     );
 
@@ -521,6 +521,7 @@ describe('SettingsDialog', () => {
     expect(screen.getByText(/Live mode can read production service account files/)).toBeTruthy();
     expect(screen.getByText('Data safety')).toBeTruthy();
     expect(screen.getByText('About')).toBeTruthy();
+    expect(screen.getByText('0.1.0')).toBeTruthy();
   });
 
   it('uses mock-specific credential storage copy', async () => {

--- a/packages/product-ui/src/settings-dialog/SettingsDialog.tsx
+++ b/packages/product-ui/src/settings-dialog/SettingsDialog.tsx
@@ -14,7 +14,7 @@ import { useAppearance } from '../appearance/AppearanceProvider.tsx';
 import { messageFromError } from '../shared/errors.ts';
 
 export interface SettingsDialogProps {
-  readonly appVersion?: string | undefined;
+  readonly appVersion: string;
   readonly dataDirectoryPath?: string | null | undefined;
   readonly density?: DensityName | undefined;
   readonly onOpenChange: (open: boolean) => void;
@@ -364,7 +364,7 @@ export function SettingsDialog(
         </div>
         <div className='grid gap-1 rounded-md border border-border-subtle bg-bg-subtle p-3 text-sm'>
           <div className='font-medium text-text-primary'>About</div>
-          <SettingRow label='Version' value={appVersion ?? 'Unavailable'} />
+          <SettingRow label='Version' value={appVersion} />
           <SettingRow label='License' value='MIT' />
         </div>
       </DialogContent>

--- a/packages/product-ui/src/settings-dialog/SettingsDialog.tsx
+++ b/packages/product-ui/src/settings-dialog/SettingsDialog.tsx
@@ -14,6 +14,7 @@ import { useAppearance } from '../appearance/AppearanceProvider.tsx';
 import { messageFromError } from '../shared/errors.ts';
 
 export interface SettingsDialogProps {
+  readonly appVersion?: string | undefined;
   readonly dataDirectoryPath?: string | null | undefined;
   readonly density?: DensityName | undefined;
   readonly onOpenChange: (open: boolean) => void;
@@ -36,6 +37,7 @@ const BYTES_PER_MB = 1024 * 1024;
 
 export function SettingsDialog(
   {
+    appVersion,
     dataDirectoryPath,
     density,
     onDensityChange,
@@ -362,7 +364,8 @@ export function SettingsDialog(
         </div>
         <div className='grid gap-1 rounded-md border border-border-subtle bg-bg-subtle p-3 text-sm'>
           <div className='font-medium text-text-primary'>About</div>
-          <div className='text-text-secondary'>Firebase Desk, MIT license.</div>
+          <SettingRow label='Version' value={appVersion ?? 'Unavailable'} />
+          <SettingRow label='License' value='MIT' />
         </div>
       </DialogContent>
     </Dialog>

--- a/scripts/check-release-version.ts
+++ b/scripts/check-release-version.ts
@@ -1,0 +1,68 @@
+import { readFile } from 'node:fs/promises';
+
+interface PackageJson {
+  readonly name?: string;
+  readonly version?: string;
+}
+
+const semverPattern = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+const problems: string[] = [];
+
+void main();
+
+async function main(): Promise<void> {
+  const rootPackage = await readPackageJson(new URL('../package.json', import.meta.url));
+  const desktopPackage = await readPackageJson(
+    new URL('../apps/desktop/package.json', import.meta.url),
+  );
+
+  const rootVersion = requireVersion(rootPackage, 'package.json');
+  const desktopVersion = requireVersion(desktopPackage, 'apps/desktop/package.json');
+
+  if (rootVersion !== desktopVersion) {
+    problems.push(
+      `package.json version ${rootVersion} must match apps/desktop/package.json version ${desktopVersion}.`,
+    );
+  }
+
+  if (!semverPattern.test(desktopVersion)) {
+    problems.push(`apps/desktop/package.json version must be semver, got ${desktopVersion}.`);
+  }
+
+  const releaseTag = releaseTagFromEnvironment();
+  if (releaseTag && releaseTag !== `v${desktopVersion}`) {
+    problems.push(
+      `Release tag ${releaseTag} must match apps/desktop/package.json version v${desktopVersion}.`,
+    );
+  }
+
+  if (problems.length > 0) {
+    console.error('Release version violations found:\n');
+    for (const problem of problems) console.error(`- ${problem}`);
+    process.exit(1);
+  }
+
+  console.log('Release version invariants OK.');
+}
+
+async function readPackageJson(url: URL): Promise<PackageJson> {
+  return JSON.parse(await readFile(url, 'utf8')) as PackageJson;
+}
+
+function requireVersion(packageJson: PackageJson, fileName: string): string {
+  if (typeof packageJson.version === 'string' && packageJson.version.length > 0) {
+    return packageJson.version;
+  }
+  problems.push(`${fileName} must declare a version.`);
+  return '';
+}
+
+function releaseTagFromEnvironment(): string | null {
+  const explicit = process.env['RELEASE_TAG'];
+  if (explicit) return explicit;
+
+  const githubRef = process.env['GITHUB_REF'];
+  if (githubRef?.startsWith('refs/tags/v')) return githubRef.replace('refs/tags/', '');
+
+  return null;
+}

--- a/scripts/write-package-manager-manifests.ts
+++ b/scripts/write-package-manager-manifests.ts
@@ -1,0 +1,123 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface ReleaseManifestAsset {
+  readonly arch: string | null;
+  readonly kind: 'checksums' | 'package';
+  readonly name: string;
+  readonly platform: string | null;
+  readonly sha256: string;
+}
+
+interface ReleaseManifest {
+  readonly assets: ReadonlyArray<ReleaseManifestAsset>;
+  readonly packageManagers: {
+    readonly homebrewTap: string;
+    readonly scoopBucket: string;
+  };
+  readonly releaseUrl: string | null;
+  readonly version: string;
+}
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+void main();
+
+async function main(): Promise<void> {
+  const manifestPath = resolve(
+    repositoryRoot,
+    process.env['RELEASE_MANIFEST_FILE'] ?? 'apps/desktop/release/release-manifest.json',
+  );
+  const outputDirectory = resolve(
+    repositoryRoot,
+    process.env['PACKAGE_MANAGER_MANIFEST_DIR'] ?? 'package-manager-manifests',
+  );
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as ReleaseManifest;
+  const repository = process.env['GITHUB_REPOSITORY'] ?? 'viniciusrmcarneiro/firebase-desk';
+  const tag = process.env['RELEASE_TAG'] ?? `v${manifest.version}`;
+  const releaseBaseUrl = `https://github.com/${repository}/releases/download/${tag}`;
+
+  await mkdir(outputDirectory, { recursive: true });
+  await writeFile(
+    resolve(outputDirectory, 'firebase-desk.rb'),
+    homebrewCask(manifest, releaseBaseUrl),
+  );
+  await writeFile(
+    resolve(outputDirectory, 'firebase-desk.json'),
+    `${JSON.stringify(scoopManifest(manifest, releaseBaseUrl), null, 2)}\n`,
+  );
+  console.log(`Wrote package manager manifests to ${outputDirectory}`);
+}
+
+function homebrewCask(manifest: ReleaseManifest, releaseBaseUrl: string): string {
+  const asset = findAsset(manifest, {
+    extension: '.dmg',
+    platform: 'macos',
+  });
+  const releaseUrl = manifest.releaseUrl
+    ?? `https://github.com/viniciusrmcarneiro/firebase-desk/releases/tag/v${manifest.version}`;
+  return `cask "firebase-desk" do
+  version "${manifest.version}"
+  sha256 "${asset.sha256}"
+
+  url "${releaseBaseUrl}/${asset.name}",
+      verified: "github.com/viniciusrmcarneiro/firebase-desk/"
+  name "Firebase Desk"
+  desc "Desktop Firebase admin client"
+  homepage "${releaseUrl}"
+
+  app "Firebase Desk.app"
+end
+`;
+}
+
+function scoopManifest(manifest: ReleaseManifest, releaseBaseUrl: string): Record<string, unknown> {
+  const asset = findAsset(manifest, {
+    extension: '.zip',
+    platform: 'windows',
+  });
+  return {
+    version: manifest.version,
+    description: 'Desktop Firebase admin client',
+    homepage: 'https://github.com/viniciusrmcarneiro/firebase-desk',
+    license: 'MIT',
+    architecture: {
+      '64bit': {
+        url: `${releaseBaseUrl}/${asset.name}`,
+        hash: asset.sha256,
+      },
+    },
+    shortcuts: [
+      ['Firebase Desk.exe', 'Firebase Desk'],
+    ],
+    checkver: {
+      github: 'https://github.com/viniciusrmcarneiro/firebase-desk',
+    },
+    autoupdate: {
+      architecture: {
+        '64bit': {
+          url:
+            'https://github.com/viniciusrmcarneiro/firebase-desk/releases/download/v$version/Firebase.Desk-v$version-$version-win-x64.zip',
+        },
+      },
+    },
+  };
+}
+
+function findAsset(
+  manifest: ReleaseManifest,
+  criteria: { readonly extension: string; readonly platform: string; },
+): ReleaseManifestAsset {
+  const asset = manifest.assets.find((item) =>
+    item.kind === 'package'
+    && item.platform === criteria.platform
+    && item.name.endsWith(criteria.extension)
+  );
+
+  if (!asset) {
+    throw new Error(`Missing ${criteria.platform} ${criteria.extension} release asset.`);
+  }
+
+  return asset;
+}

--- a/scripts/write-package-manager-manifests.ts
+++ b/scripts/write-package-manager-manifests.ts
@@ -36,33 +36,37 @@ async function main(): Promise<void> {
   const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as ReleaseManifest;
   const repository = process.env['GITHUB_REPOSITORY'] ?? 'viniciusrmcarneiro/firebase-desk';
   const tag = process.env['RELEASE_TAG'] ?? `v${manifest.version}`;
-  const releaseBaseUrl = `https://github.com/${repository}/releases/download/${tag}`;
+  const releaseBaseUrl = releaseDownloadBaseUrl(repository, tag);
 
   await mkdir(outputDirectory, { recursive: true });
   await writeFile(
     resolve(outputDirectory, 'firebase-desk.rb'),
-    homebrewCask(manifest, releaseBaseUrl),
+    homebrewCask(manifest, repository, releaseBaseUrl),
   );
   await writeFile(
     resolve(outputDirectory, 'firebase-desk.json'),
-    `${JSON.stringify(scoopManifest(manifest, releaseBaseUrl), null, 2)}\n`,
+    `${JSON.stringify(scoopManifest(manifest, repository, releaseBaseUrl), null, 2)}\n`,
   );
   console.log(`Wrote package manager manifests to ${outputDirectory}`);
 }
 
-function homebrewCask(manifest: ReleaseManifest, releaseBaseUrl: string): string {
+function homebrewCask(
+  manifest: ReleaseManifest,
+  repository: string,
+  releaseBaseUrl: string,
+): string {
   const asset = findAsset(manifest, {
     extension: '.dmg',
     platform: 'macos',
   });
   const releaseUrl = manifest.releaseUrl
-    ?? `https://github.com/viniciusrmcarneiro/firebase-desk/releases/tag/v${manifest.version}`;
+    ?? `https://github.com/${repository}/releases/tag/v${manifest.version}`;
   return `cask "firebase-desk" do
   version "${manifest.version}"
   sha256 "${asset.sha256}"
 
-  url "${releaseBaseUrl}/${asset.name}",
-      verified: "github.com/viniciusrmcarneiro/firebase-desk/"
+  url "${assetUrl(releaseBaseUrl, asset.name)}",
+      verified: "github.com/${repository}/"
   name "Firebase Desk"
   desc "Desktop Firebase admin client"
   homepage "${releaseUrl}"
@@ -72,19 +76,26 @@ end
 `;
 }
 
-function scoopManifest(manifest: ReleaseManifest, releaseBaseUrl: string): Record<string, unknown> {
+function scoopManifest(
+  manifest: ReleaseManifest,
+  repository: string,
+  releaseBaseUrl: string,
+): Record<string, unknown> {
   const asset = findAsset(manifest, {
     extension: '.zip',
     platform: 'windows',
   });
+  const repositoryUrl = `https://github.com/${repository}`;
+  const autoupdateBaseUrl = releaseDownloadBaseUrl(repository, 'v$version');
+  const autoupdateAssetName = asset.name.replaceAll(manifest.version, '$version');
   return {
     version: manifest.version,
     description: 'Desktop Firebase admin client',
-    homepage: 'https://github.com/viniciusrmcarneiro/firebase-desk',
+    homepage: repositoryUrl,
     license: 'MIT',
     architecture: {
       '64bit': {
-        url: `${releaseBaseUrl}/${asset.name}`,
+        url: assetUrl(releaseBaseUrl, asset.name),
         hash: asset.sha256,
       },
     },
@@ -92,13 +103,12 @@ function scoopManifest(manifest: ReleaseManifest, releaseBaseUrl: string): Recor
       ['Firebase Desk.exe', 'Firebase Desk'],
     ],
     checkver: {
-      github: 'https://github.com/viniciusrmcarneiro/firebase-desk',
+      github: repositoryUrl,
     },
     autoupdate: {
       architecture: {
         '64bit': {
-          url:
-            'https://github.com/viniciusrmcarneiro/firebase-desk/releases/download/v$version/Firebase.Desk-v$version-$version-win-x64.zip',
+          url: assetUrl(autoupdateBaseUrl, autoupdateAssetName),
         },
       },
     },
@@ -120,4 +130,16 @@ function findAsset(
   }
 
   return asset;
+}
+
+function releaseDownloadBaseUrl(repository: string, tag: string): string {
+  return `https://github.com/${repository}/releases/download/${encodePathSegment(tag)}`;
+}
+
+function assetUrl(releaseBaseUrl: string, assetName: string): string {
+  return `${releaseBaseUrl}/${encodePathSegment(assetName)}`;
+}
+
+function encodePathSegment(value: string): string {
+  return encodeURIComponent(value).replaceAll('%24version', '$version');
 }

--- a/scripts/write-release-manifest.ts
+++ b/scripts/write-release-manifest.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { createReadStream } from 'node:fs';
 import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
-import { basename, dirname, extname, relative, resolve } from 'node:path';
+import { basename, dirname, extname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 interface PackageJson {
@@ -101,7 +101,7 @@ async function assetFromFile(root: string, filePath: string): Promise<ReleaseMan
     arch: archFromName(basename(filePath)),
     kind: isChecksumFile(filePath) ? 'checksums' : 'package',
     name: basename(filePath),
-    path: relative(root, filePath),
+    path: basename(filePath),
     platform: platformFromName(basename(filePath)),
     sha256: await digest(filePath),
     size: fileStat.size,

--- a/scripts/write-release-manifest.ts
+++ b/scripts/write-release-manifest.ts
@@ -60,7 +60,7 @@ async function main(): Promise<void> {
   }
 
   const assets = await Promise.all(
-    sortStrings(candidates).map(async (filePath) => assetFromFile(artifactsDirectory, filePath)),
+    sortStrings(candidates).map(assetFromFile),
   );
   const manifest: ReleaseManifest = {
     appId: 'dev.firebase-desk.app',
@@ -95,7 +95,7 @@ async function recursiveFiles(directory: string): Promise<ReadonlyArray<string>>
   return files.concat(...nestedFiles);
 }
 
-async function assetFromFile(root: string, filePath: string): Promise<ReleaseManifestAsset> {
+async function assetFromFile(filePath: string): Promise<ReleaseManifestAsset> {
   const fileStat = await stat(filePath);
   return {
     arch: archFromName(basename(filePath)),

--- a/scripts/write-release-manifest.ts
+++ b/scripts/write-release-manifest.ts
@@ -1,0 +1,145 @@
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { basename, dirname, extname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface PackageJson {
+  readonly version: string;
+}
+
+interface ReleaseManifestAsset {
+  readonly arch: string | null;
+  readonly kind: 'checksums' | 'package';
+  readonly name: string;
+  readonly path: string;
+  readonly platform: string | null;
+  readonly sha256: string;
+  readonly size: number;
+}
+
+interface ReleaseManifest {
+  readonly appId: 'dev.firebase-desk.app';
+  readonly assets: ReadonlyArray<ReleaseManifestAsset>;
+  readonly channel: string;
+  readonly commit: string;
+  readonly generatedAt: string;
+  readonly packageManagers: {
+    readonly homebrewTap: string;
+    readonly scoopBucket: string;
+  };
+  readonly releaseUrl: string | null;
+  readonly schemaVersion: 1;
+  readonly version: string;
+}
+
+const repositoryRoot = fileURLToRepositoryRoot();
+const artifactExtensions = new Set(['.AppImage', '.deb', '.dmg', '.exe', '.zip']);
+
+void main();
+
+async function main(): Promise<void> {
+  const artifactsDirectory = resolve(
+    repositoryRoot,
+    process.env['RELEASE_ARTIFACTS_DIR'] ?? 'apps/desktop/release',
+  );
+  const outputPath = resolve(
+    repositoryRoot,
+    process.env['RELEASE_MANIFEST_FILE'] ?? 'apps/desktop/release/release-manifest.json',
+  );
+  const desktopPackage = JSON.parse(
+    await readFile(resolve(repositoryRoot, 'apps/desktop/package.json'), 'utf8'),
+  ) as PackageJson;
+  const files = await recursiveFiles(artifactsDirectory);
+  const candidates = files.filter((filePath) =>
+    isPackageArtifact(filePath) || isChecksumFile(filePath)
+  );
+
+  if (candidates.length === 0) {
+    throw new Error(`No release artifacts found in ${artifactsDirectory}`);
+  }
+
+  const assets = await Promise.all(
+    sortStrings(candidates).map(async (filePath) => assetFromFile(artifactsDirectory, filePath)),
+  );
+  const manifest: ReleaseManifest = {
+    appId: 'dev.firebase-desk.app',
+    assets,
+    channel: process.env['RELEASE_CHANNEL'] ?? 'local',
+    commit: process.env['RELEASE_COMMIT'] ?? process.env['GITHUB_SHA'] ?? 'local',
+    generatedAt: new Date().toISOString(),
+    packageManagers: {
+      homebrewTap: process.env['HOMEBREW_TAP_REPOSITORY'] ?? 'viniciusrmcarneiro/homebrew-tap',
+      scoopBucket: process.env['SCOOP_BUCKET_REPOSITORY'] ?? 'viniciusrmcarneiro/scoop-bucket',
+    },
+    releaseUrl: process.env['RELEASE_URL'] ?? null,
+    schemaVersion: 1,
+    version: process.env['RELEASE_VERSION'] ?? desktopPackage.version,
+  };
+
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  console.log(`Wrote ${outputPath}`);
+}
+
+async function recursiveFiles(directory: string): Promise<ReadonlyArray<string>> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => resolve(directory, entry.name));
+  const nestedFiles = await Promise.all(
+    entries.filter((entry) => entry.isDirectory()).map((entry) =>
+      recursiveFiles(resolve(directory, entry.name))
+    ),
+  );
+  return files.concat(...nestedFiles);
+}
+
+async function assetFromFile(root: string, filePath: string): Promise<ReleaseManifestAsset> {
+  const fileStat = await stat(filePath);
+  return {
+    arch: archFromName(basename(filePath)),
+    kind: isChecksumFile(filePath) ? 'checksums' : 'package',
+    name: basename(filePath),
+    path: relative(root, filePath),
+    platform: platformFromName(basename(filePath)),
+    sha256: await digest(filePath),
+    size: fileStat.size,
+  };
+}
+
+function isPackageArtifact(filePath: string): boolean {
+  return artifactExtensions.has(extname(filePath));
+}
+
+function isChecksumFile(filePath: string): boolean {
+  return basename(filePath).startsWith('SHA256SUMS') && filePath.endsWith('.txt');
+}
+
+async function digest(filePath: string): Promise<string> {
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(filePath)) hash.update(chunk);
+  return hash.digest('hex');
+}
+
+function platformFromName(fileName: string): string | null {
+  if (fileName.includes('mac') || fileName.includes('macos')) return 'macos';
+  if (fileName.includes('win') || fileName.includes('windows')) return 'windows';
+  if (fileName.includes('linux')) return 'linux';
+  return null;
+}
+
+function archFromName(fileName: string): string | null {
+  if (fileName.includes('arm64') || fileName.includes('ARM64')) return 'arm64';
+  if (fileName.includes('x64') || fileName.includes('X64')) return 'x64';
+  if (fileName.includes('x86_64') || fileName.includes('amd64')) return 'x64';
+  return null;
+}
+
+function sortStrings(values: ReadonlyArray<string>): string[] {
+  return [...values].sort((left, right) => left.localeCompare(right));
+}
+
+function fileURLToRepositoryRoot(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), '..');
+}


### PR DESCRIPTION
## Summary
- set first release version to 0.0.1
- require desktop version bumps unless PR title has [skip release]
- gate main releases on actual desktop version changes
- generate release manifest plus Homebrew/Scoop manifests
- show app version in Settings

## Issues
Fixes #22.
Related #25, but does not close it. Update detection/notification UI is still future work.

## Checks
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm test:release-version
- release manifest smoke with temp artifacts