### PR TITLE
[skip release] Auto release on merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,19 +324,33 @@ jobs:
                     exit 1
                   fi
 
+                  expected_sha="$(git rev-parse HEAD)"
                   tag_ref="repos/$GITHUB_REPOSITORY/git/ref/tags/$VERSION_TAG"
                   if tag_json="$(gh api "$tag_ref" 2>/dev/null)"; then
-                    tag_sha="$(printf '%s' "$tag_json" | jq -r '.object.sha')"
-                    if [ "$tag_sha" != "$GITHUB_SHA" ]; then
-                      echo "::error::Tag $VERSION_TAG points to $tag_sha, expected $GITHUB_SHA."
+                    resolved_sha="$(printf '%s' "$tag_json" | jq -r '.object.sha')"
+                    resolved_type="$(printf '%s' "$tag_json" | jq -r '.object.type')"
+
+                    while [ "$resolved_type" = "tag" ]; do
+                      tag_object="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$resolved_sha")"
+                      resolved_sha="$(printf '%s' "$tag_object" | jq -r '.object.sha')"
+                      resolved_type="$(printf '%s' "$tag_object" | jq -r '.object.type')"
+                    done
+
+                    if [ "$resolved_type" != "commit" ]; then
+                      echo "::error::Tag $VERSION_TAG resolves to $resolved_type $resolved_sha, expected commit $expected_sha."
                       exit 1
                     fi
-                    echo "Tag $VERSION_TAG already points to $GITHUB_SHA."
+
+                    if [ "$resolved_sha" != "$expected_sha" ]; then
+                      echo "::error::Tag $VERSION_TAG resolves to $resolved_sha, expected $expected_sha."
+                      exit 1
+                    fi
+                    echo "Tag $VERSION_TAG already resolves to $expected_sha."
                   else
                     gh api "repos/$GITHUB_REPOSITORY/git/refs" \
                       -f ref="refs/tags/$VERSION_TAG" \
-                      -f sha="$GITHUB_SHA" >/dev/null
-                    echo "Created tag $VERSION_TAG at $GITHUB_SHA."
+                      -f sha="$expected_sha" >/dev/null
+                    echo "Created tag $VERSION_TAG at $expected_sha."
                   fi
             - name: Publish version release
               env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
             release_channel: ${{ steps.plan.outputs.release_channel }}
             retention_days: ${{ steps.plan.outputs.retention_days }}
             should_package: ${{ steps.plan.outputs.should_package }}
+            version_tag: ${{ steps.plan.outputs.version_tag }}
         steps:
             - uses: actions/github-script@v8
               id: plan
@@ -62,6 +63,7 @@ jobs:
                       let retentionDays = '14';
                       let includeAllPlatforms = eventName === 'workflow_dispatch';
                       let shouldPackage = true;
+                      let versionTag = '';
 
                       if (eventName === 'pull_request') {
                           const pullRequest = context.payload.pull_request;
@@ -82,27 +84,29 @@ jobs:
                           core.info(`PR package-all label: ${hasPackageAllLabel}`);
                           core.info(`PR touches package paths: ${touchesPackagePaths}`);
                       } else if (eventName === 'push' && ref === 'refs/heads/main') {
-                          releaseChannel = 'latest';
                           retentionDays = '90';
                           includeAllPlatforms = true;
+                          async function desktopVersionAt(ref) {
+                              const response = await github.rest.repos.getContent({
+                                  owner: context.repo.owner,
+                                  repo: context.repo.repo,
+                                  path: 'apps/desktop/package.json',
+                                  ref,
+                              });
+                              if (!('content' in response.data)) {
+                                  throw new Error('apps/desktop/package.json is not a file.');
+                              }
+                              return JSON.parse(
+                                  Buffer.from(response.data.content, 'base64').toString('utf8'),
+                              ).version;
+                          }
+                          const headVersion = await desktopVersionAt(context.sha);
+                          versionTag = `v${headVersion}`;
+                          releaseChannel = versionTag;
+
                           const before = context.payload.before;
                           if (before && !/^0+$/.test(before)) {
-                              async function desktopVersionAt(ref) {
-                                  const response = await github.rest.repos.getContent({
-                                      owner: context.repo.owner,
-                                      repo: context.repo.repo,
-                                      path: 'apps/desktop/package.json',
-                                      ref,
-                                  });
-                                  if (!('content' in response.data)) {
-                                      throw new Error('apps/desktop/package.json is not a file.');
-                                  }
-                                  return JSON.parse(
-                                      Buffer.from(response.data.content, 'base64').toString('utf8'),
-                                  ).version;
-                              }
                               const beforeVersion = await desktopVersionAt(before);
-                              const headVersion = await desktopVersionAt(context.sha);
                               shouldPackage = beforeVersion !== headVersion;
                               const comparison = await github.rest.repos.compareCommitsWithBasehead({
                                   owner: context.repo.owner,
@@ -118,6 +122,7 @@ jobs:
                           }
                       } else if (eventName === 'push' && ref.startsWith('refs/tags/')) {
                           releaseChannel = ref.replace('refs/tags/', '');
+                          versionTag = releaseChannel;
                           retentionDays = '90';
                           includeAllPlatforms = true;
                       }
@@ -127,6 +132,7 @@ jobs:
                       };
 
                       core.info(`Release channel: ${releaseChannel}`);
+                      core.info(`Version tag: ${versionTag}`);
                       core.info(`Retention days: ${retentionDays}`);
                       core.info(`Package matrix: ${JSON.stringify(matrix)}`);
                       core.info(`Should package: ${shouldPackage}`);
@@ -134,6 +140,7 @@ jobs:
                       core.setOutput('release_channel', releaseChannel);
                       core.setOutput('retention_days', retentionDays);
                       core.setOutput('should_package', String(shouldPackage));
+                      core.setOutput('version_tag', versionTag);
 
     ci:
         uses: ./.github/workflows/ci.yml
@@ -147,7 +154,7 @@ jobs:
             matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
         env:
             GCLOUD_PROJECT: demo-local
-            RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
+            RELEASE_TAG: ${{ needs.prepare.outputs.version_tag }}
             RELEASE_CHANNEL: ${{ needs.prepare.outputs.release_channel }}
         steps:
             - uses: actions/checkout@v6
@@ -246,7 +253,7 @@ jobs:
                   ROLLING_RELEASE_TAG: latest
               run: |
                   cat > release-notes.md <<'NOTES'
-                  Rolling unsigned development build from the latest `main` commit.
+                  Rolling unsigned build mirrored from the latest versioned `main` release.
 
                   These binaries are published intentionally for development smoke testing. They are unsigned, so OS warning prompts are expected. Verify downloads with the matching SHA256SUMS asset.
                   NOTES
@@ -265,10 +272,13 @@ jobs:
                   fi
                   find artifacts -type f -print0 | xargs -0 -I {} gh release upload "$ROLLING_RELEASE_TAG" {} --repo "$GITHUB_REPOSITORY" --clobber
 
-    publish-tag:
+    publish-version:
         needs: [ prepare, package ]
         runs-on: ubuntu-latest
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        if: >
+            (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+            || (github.event_name == 'push' && github.ref == 'refs/heads/main'
+            && needs.prepare.outputs.should_package == 'true')
         permissions:
             contents: write
         steps:
@@ -288,26 +298,64 @@ jobs:
               run: pnpm release:manifest
               env:
                   RELEASE_ARTIFACTS_DIR: artifacts
-                  RELEASE_CHANNEL: ${{ github.ref_name }}
+                  RELEASE_CHANNEL: ${{ needs.prepare.outputs.version_tag }}
                   RELEASE_MANIFEST_FILE: artifacts/release-manifest.json
-                  RELEASE_TAG: ${{ github.ref_name }}
-                  RELEASE_URL: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+                  RELEASE_TAG: ${{ needs.prepare.outputs.version_tag }}
+                  RELEASE_URL: https://github.com/${{ github.repository }}/releases/tag/${{ needs.prepare.outputs.version_tag }}
             - name: Write package manager manifests
               run: pnpm package-managers:manifests
               env:
                   PACKAGE_MANAGER_MANIFEST_DIR: package-manager-manifests
                   RELEASE_MANIFEST_FILE: artifacts/release-manifest.json
-                  RELEASE_TAG: ${{ github.ref_name }}
+                  RELEASE_TAG: ${{ needs.prepare.outputs.version_tag }}
             - uses: actions/upload-artifact@v7
               with:
-                  name: package-manager-manifests-${{ github.ref_name }}
+                  name: package-manager-manifests-${{ needs.prepare.outputs.version_tag }}
                   path: package-manager-manifests
                   if-no-files-found: error
                   retention-days: 90
-            - uses: softprops/action-gh-release@v3
-              with:
-                  draft: false
-                  prerelease: false
-                  body: |
-                      Unsigned Firebase Desk build. OS warning prompts are expected. Verify downloads with the matching SHA256SUMS asset.
-                  files: artifacts/**/*
+            - name: Ensure version tag
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  VERSION_TAG: ${{ needs.prepare.outputs.version_tag }}
+              run: |
+                  if [ -z "$VERSION_TAG" ]; then
+                    echo "::error::Missing version tag."
+                    exit 1
+                  fi
+
+                  tag_ref="repos/$GITHUB_REPOSITORY/git/ref/tags/$VERSION_TAG"
+                  if tag_json="$(gh api "$tag_ref" 2>/dev/null)"; then
+                    tag_sha="$(printf '%s' "$tag_json" | jq -r '.object.sha')"
+                    if [ "$tag_sha" != "$GITHUB_SHA" ]; then
+                      echo "::error::Tag $VERSION_TAG points to $tag_sha, expected $GITHUB_SHA."
+                      exit 1
+                    fi
+                    echo "Tag $VERSION_TAG already points to $GITHUB_SHA."
+                  else
+                    gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+                      -f ref="refs/tags/$VERSION_TAG" \
+                      -f sha="$GITHUB_SHA" >/dev/null
+                    echo "Created tag $VERSION_TAG at $GITHUB_SHA."
+                  fi
+            - name: Publish version release
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  MARK_LATEST: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
+                  VERSION_TAG: ${{ needs.prepare.outputs.version_tag }}
+              run: |
+                  cat > release-notes.md <<'NOTES'
+                  Unsigned Firebase Desk build. OS warning prompts are expected. Verify downloads with the matching SHA256SUMS asset.
+                  NOTES
+
+                  latest_args=()
+                  if [ "$MARK_LATEST" = "true" ]; then
+                    latest_args=(--latest)
+                  fi
+
+                  if gh release view "$VERSION_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+                    gh release edit "$VERSION_TAG" --repo "$GITHUB_REPOSITORY" "${latest_args[@]}" --title "$VERSION_TAG" --notes-file release-notes.md
+                  else
+                    gh release create "$VERSION_TAG" --repo "$GITHUB_REPOSITORY" "${latest_args[@]}" --verify-tag --title "$VERSION_TAG" --notes-file release-notes.md
+                  fi
+                  find artifacts -type f -print0 | xargs -0 -I {} gh release upload "$VERSION_TAG" {} --repo "$GITHUB_REPOSITORY" --clobber

--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ The Docker wrapper runs the Ubuntu image as `linux/amd64` and grants the Chromiu
 
 Firebase Desk publishes unsigned binaries with SHA-256 checksums. We do not plan to sign binaries; package-manager distribution starts with self-owned Homebrew and Scoop manifests.
 
-| Event           | Output                                                                                                                   |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| PR to `main`    | CI, package Linux; package macOS/Windows when `package-all` or package paths change; upload temporary workflow artifacts |
-| Merge to `main` | CI, package macOS/Windows/Linux, publish/update prerelease `latest` when the desktop version changed                     |
-| Tag `v*.*.*`    | CI, package macOS/Windows/Linux, publish a stable versioned release                                                      |
-| Manual dispatch | Ad-hoc package smoke run with temporary workflow artifacts                                                               |
+| Event           | Output                                                                                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| PR to `main`    | CI, package Linux; package macOS/Windows when `package-all` or package paths change; upload temporary workflow artifacts                    |
+| Merge to `main` | CI, package macOS/Windows/Linux, create `vX.Y.Z`, publish a stable release, and update prerelease `latest` when the desktop version changed |
+| Tag `v*.*.*`    | CI, package macOS/Windows/Linux, publish or repair a stable versioned release                                                               |
+| Manual dispatch | Ad-hoc package smoke run with temporary workflow artifacts                                                                                  |
 
-Use PR artifacts to block broken packaging before merge. Use GitHub Release assets from `latest` and version tags as the long-lived download links. The rolling `latest` tag is created once and kept stable; the release assets and notes are updated only when the desktop package version changes.
+Use PR artifacts to block broken packaging before merge. Use GitHub Release assets from version tags as stable download links. The rolling `latest` tag is created once and kept stable; the release assets and notes mirror the newest versioned `main` release only when the desktop package version changes.
 
 Pull requests to `main` must change `apps/desktop/package.json` version unless the title includes `[skip release]`. Version tags must match the desktop package version, for example `v0.1.0` requires `apps/desktop/package.json` version `0.1.0`.
 
@@ -80,7 +80,7 @@ Pull requests to `main` must change `apps/desktop/package.json` version unless t
 
 Artifact names include channel/version, OS, architecture, and target extension. PR and manual-dispatch artifacts are temporary workflow artifacts, not release assets. Each package artifact set includes a matching `SHA256SUMS*.txt` file.
 
-Versioned releases also include `release-manifest.json`. Tag workflows generate Homebrew cask and Scoop manifests as workflow artifacts for self-owned package manager distribution.
+Versioned releases also include `release-manifest.json`. Version release workflows generate Homebrew cask and Scoop manifests as workflow artifacts for self-owned package manager distribution.
 
 ## Checksums
 

--- a/docs/package-managers.md
+++ b/docs/package-managers.md
@@ -1,13 +1,14 @@
 # Package Managers
 
-Firebase Desk starts package-manager distribution with self-owned manifests generated from stable version tags.
+Firebase Desk starts package-manager distribution with self-owned manifests generated from stable version releases.
 
 ## Channels
 
 - GitHub Releases remain the source of binaries and checksums.
-- `latest` is a rolling prerelease for smoke testing.
-- `vX.Y.Z` tags are stable releases for package managers.
-- Generated package-manager manifests are workflow artifacts on tag releases.
+- `latest` mirrors the newest versioned `main` release for smoke testing.
+- Merges to `main` with a desktop version bump create `vX.Y.Z` tags and stable releases.
+- Manually pushed `vX.Y.Z` tags can publish or repair stable releases.
+- Generated package-manager manifests are workflow artifacts on stable version releases.
 
 ## First Targets
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,6 +1,6 @@
 # Release Checklist
 
-Use this for unsigned releases. `latest` is a rolling prerelease. Version tags are stable releases with SHA-256 checksums. Signing/notarization/code-signing are intentionally out of scope.
+Use this for unsigned releases. Merges with a desktop version bump publish stable releases automatically. `latest` mirrors the newest versioned `main` release. Signing/notarization/code-signing are intentionally out of scope.
 
 ## Before Merge
 
@@ -15,26 +15,30 @@ Use this for unsigned releases. `latest` is a rolling prerelease. Version tags a
 - [ ] macOS packaged smoke passed if the PR ran the full matrix.
 - [ ] Windows unpacked-app check passed if the PR ran the full matrix.
 
-## Rolling Main Build
+## Main Release
 
 - [ ] Merge to `main`.
 - [ ] Confirm merged PR changed `apps/desktop/package.json`; otherwise no rolling release is expected.
 - [ ] `release.yml` package job green on macOS, Windows, and Linux.
+- [ ] Version tag `vX.Y.Z` created from `apps/desktop/package.json`.
+- [ ] Stable GitHub release `vX.Y.Z` created or updated.
+- [ ] `release-manifest.json` attached to `vX.Y.Z`.
+- [ ] Package manager manifest workflow artifact exists.
 - [ ] `latest` tag exists.
 - [ ] `latest` prerelease created or updated.
-- [ ] Release assets attached for macOS, Windows, and Linux targets.
+- [ ] Release assets attached for macOS, Windows, and Linux targets on `vX.Y.Z` and `latest`.
 - [ ] Matching `SHA256SUMS*.txt` assets attached for macOS, Windows, and Linux packages.
-- [ ] Download each `latest` asset.
+- [ ] Download each `vX.Y.Z` asset.
 - [ ] Verify every downloaded asset against the matching `SHA256SUMS*.txt` file.
 - [ ] Install/open macOS asset.
 - [ ] Install/open Windows asset.
 - [ ] Install/open Linux asset.
 
-## First Versioned Release
+## First Release
 
-- [ ] Confirm `latest` artifacts open on each OS.
 - [ ] Confirm root and desktop package versions are `0.0.1`.
-- [ ] Create tag: `git tag v0.0.1 && git push origin v0.0.1`.
+- [ ] Merge the release PR.
+- [ ] Confirm `release.yml` creates tag `v0.0.1`.
 - [ ] Confirm `release.yml` creates a published GitHub release for `v0.0.1`.
 - [ ] Download each versioned asset.
 - [ ] Verify every downloaded asset against the matching `SHA256SUMS*.txt` file.

--- a/docs/testing-ci.md
+++ b/docs/testing-ci.md
@@ -18,7 +18,7 @@ This doc explains how testing runs in CI, release, and package validation. Test 
 - `ci.yml`: install (pnpm), run `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test:coverage`, publish the coverage summary, then `pnpm build`.
 - `e2e.yml`: install, build affected workspaces, start Firebase emulators, seed data, run `pnpm test:e2e`, upload traces/screenshots on failure.
 - `release-gate.yml`: on PRs to `main`, require `apps/desktop/package.json` to change unless the PR title includes `[skip release]`.
-- `release.yml`: on PR, merge to `main`, tag, or ad-hoc dispatch, run CI checks and `pnpm package` for the desktop app. PRs always package Linux, and package macOS/Windows when the PR has the `package-all` label or touches package-sensitive paths (`apps/desktop/**`, `e2e/**`, release workflows, package scripts, or lockfile). Linux, macOS, and Windows all run the packaged smoke check against the built app. PR and ad-hoc runs upload temporary workflow artifacts with retention. Merges to `main` create or update the rolling published prerelease `latest` only when the desktop package version changed. Version tags create stable releases with release assets, SHA-256 checksums, `release-manifest.json`, and package manager manifest artifacts.
+- `release.yml`: on PR, merge to `main`, tag, or ad-hoc dispatch, run CI checks and `pnpm package` for the desktop app. PRs always package Linux, and package macOS/Windows when the PR has the `package-all` label or touches package-sensitive paths (`apps/desktop/**`, `e2e/**`, release workflows, package scripts, or lockfile). Linux, macOS, and Windows all run the packaged smoke check against the built app. PR and ad-hoc runs upload temporary workflow artifacts with retention. Merges to `main` with a desktop version change create `vX.Y.Z`, publish the stable release, and update `latest`. Manually pushed version tags publish or repair stable releases with release assets, SHA-256 checksums, `release-manifest.json`, and package manager manifest artifacts.
 
 ### Required Scripts (root `package.json`, delegated via turbo/pnpm filters)
 
@@ -59,9 +59,9 @@ This doc explains how testing runs in CI, release, and package validation. Test 
 - Release workflow must exist before the first packaged build is considered done.
 - PR package outputs are workflow artifacts only, not GitHub Release assets.
 - PR and manual package artifacts use short retention; main and tag artifacts use longer retention.
-- Merges to `main` with a desktop version change update the rolling published prerelease `latest`; keep its tag stable and update assets instead of deleting/recreating the release.
+- Merges to `main` with a desktop version change publish `vX.Y.Z` automatically and update the rolling published prerelease `latest`; keep the `latest` tag stable and update assets instead of deleting/recreating the release.
 - Merges to `main` without a desktop version change do not publish a rolling release.
-- Version tags create separate published stable releases.
+- Version tags create or repair separate published stable releases.
 - Version tags must match `apps/desktop/package.json`.
 - Unsigned builds are published intentionally with SHA-256 checksums; binary signing is not planned.
 - Package-manager distribution starts with self-owned Homebrew and Scoop manifests generated from versioned releases.


### PR DESCRIPTION
## Summary
- create version tags from main release runs
- publish stable version releases automatically after package checks
- keep latest as a mirror of newest versioned main release
- update release docs/checklist

## Checks
- pnpm format:check
- YAML parse
- git diff --check