### PR TITLE
[codex][skip release] ignore dependabot majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"           # Target the root where the lockfile resides
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     groups:                  # Recommended to avoid PR fatigue in monorepos
       dependencies:
         patterns:


### PR DESCRIPTION
## What
- Ignore Dependabot semver-major npm updates.
- Keep weekly grouped minor/patch updates.

## Why
- Avoid major-version PR noise.

## Check
- `pnpm format:check`