### PR TITLE
[codex] native app basics

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebase-desk/desktop",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "license": "MIT",
   "description": "Firebase Desk Electron application.",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,7 +1,17 @@
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, screen } from 'electron';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { registerIpcHandlers } from './ipc/registry.ts';
+import {
+  installNativeAppBehavior,
+  installNativeWindowBehavior,
+  mainWindowDefaults,
+} from './native-app.ts';
+import {
+  loadMainWindowState,
+  trackMainWindowState,
+  windowOptionsFromState,
+} from './window-state-store.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const userDataDir = process.env['FIREBASE_DESK_USER_DATA_DIR'];
@@ -9,16 +19,23 @@ const userDataDir = process.env['FIREBASE_DESK_USER_DATA_DIR'];
 if (userDataDir) app.setPath('userData', userDataDir);
 
 async function createWindow(): Promise<void> {
+  const userDataPath = app.getPath('userData');
+  const windowState = await loadMainWindowState(userDataPath);
   const window = new BrowserWindow({
-    width: 1280,
-    height: 820,
-    title: 'Firebase Desk',
+    ...mainWindowDefaults(),
+    ...windowOptionsFromState(
+      windowState,
+      screen.getAllDisplays().map((display) => display.workArea),
+    ),
     webPreferences: {
       preload: resolve(__dirname, '../preload/index.cjs'),
       contextIsolation: true,
       sandbox: true,
     },
   });
+  installNativeWindowBehavior(window);
+  trackMainWindowState(window, userDataPath);
+  if (windowState?.maximized) window.maximize();
 
   if (process.env['ELECTRON_RENDERER_URL']) {
     await window.loadURL(process.env['ELECTRON_RENDERER_URL']);
@@ -28,6 +45,7 @@ async function createWindow(): Promise<void> {
 }
 
 app.whenReady().then(async () => {
+  installNativeAppBehavior();
   registerIpcHandlers();
   await createWindow();
 

--- a/apps/desktop/src/main/ipc/registry.test.ts
+++ b/apps/desktop/src/main/ipc/registry.test.ts
@@ -14,21 +14,29 @@ import {
 } from './registry.ts';
 
 const electronMocks = vi.hoisted(() => ({
+  getFocusedWindow: vi.fn(() => null),
   getAllWindows: vi.fn(),
   handle: vi.fn(),
+  notificationIsSupported: vi.fn(() => false),
 }));
 
 vi.mock('electron', () => ({
   app: { getPath: vi.fn(() => '/tmp/firebase-desk-test'), getVersion: vi.fn(() => '0.0.0') },
-  BrowserWindow: { getAllWindows: electronMocks.getAllWindows },
+  BrowserWindow: {
+    getAllWindows: electronMocks.getAllWindows,
+    getFocusedWindow: electronMocks.getFocusedWindow,
+  },
   dialog: { showOpenDialog: vi.fn() },
   ipcMain: { handle: electronMocks.handle },
+  Menu: { buildFromTemplate: vi.fn(), setApplicationMenu: vi.fn() },
+  nativeTheme: { themeSource: 'system' },
+  Notification: { isSupported: electronMocks.notificationIsSupported },
   safeStorage: {
     isEncryptionAvailable: () => false,
     encryptString: (value: string) => Buffer.from(value),
     decryptString: (value: Buffer) => value.toString('utf8'),
   },
-  shell: { openPath: vi.fn() },
+  shell: { openExternal: vi.fn(), openPath: vi.fn() },
 }));
 
 describe('IPC handler registry', () => {

--- a/apps/desktop/src/main/ipc/registry.ts
+++ b/apps/desktop/src/main/ipc/registry.ts
@@ -22,6 +22,7 @@ import { fileURLToPath } from 'node:url';
 import { MainActivityLogRepository } from '../activity/main-activity-log-repository.ts';
 import { MainBackgroundJobRepository } from '../jobs/background-job-repository.ts';
 import { FirestoreCollectionJobRunner } from '../jobs/firestore-collection-job-runner.ts';
+import { createBackgroundJobNotifier } from '../native-app.ts';
 import { MainProjectsRepository } from '../projects/main-projects-repository.ts';
 import { MainSettingsRepository } from '../settings/main-settings-repository.ts';
 import { ActivityLogStore } from '../storage/activity-log-store.ts';
@@ -85,7 +86,11 @@ export function registerIpcHandlers(): void {
     }),
     activityLogRepository,
   );
-  jobsRepository.subscribe(broadcastBackgroundJobEvent);
+  const notifyBackgroundJob = createBackgroundJobNotifier();
+  jobsRepository.subscribe((event) => {
+    broadcastBackgroundJobEvent(event);
+    notifyBackgroundJob(event);
+  });
   void jobsRepository.initialize();
   const authProvider = new AdminAuthProvider(connectionResolver);
   const scriptRunnerRepository = new ProcessScriptRunnerRepository(connectionResolver, {

--- a/apps/desktop/src/main/jobs/firestore-collection-job-runner.test.ts
+++ b/apps/desktop/src/main/jobs/firestore-collection-job-runner.test.ts
@@ -66,6 +66,25 @@ describe('FirestoreCollectionJobRunner', () => {
     expect(db.commits.flat()).toEqual(['orders_copy/order_1']);
   });
 
+  it('splits copy writes by estimated request payload size', async () => {
+    const db = new FakeFirestore(
+      { orders: ['orders/order_1', 'orders/order_2', 'orders/order_3'] },
+      {
+        'orders/order_1': { body: 'x'.repeat(120) },
+        'orders/order_2': { body: 'x'.repeat(120) },
+        'orders/order_3': { body: 'x'.repeat(120) },
+      },
+    );
+    const runner = new FirestoreCollectionJobRunner(provider(db), {
+      tempDirectory: '/tmp',
+      writeBatchMaxBytes: 1000,
+    });
+
+    await runner.run(copyJob('overwrite'), neverCancelled(), { update: vi.fn() });
+
+    expect(db.commits.map((commit) => commit.length)).toEqual([1, 1, 1]);
+  });
+
   it('imports encoded JSONL with batched collision checks', async () => {
     const dir = await makeTempDir();
     const filePath = join(dir, 'import.jsonl');

--- a/apps/desktop/src/main/jobs/firestore-collection-job-runner.test.ts
+++ b/apps/desktop/src/main/jobs/firestore-collection-job-runner.test.ts
@@ -85,6 +85,22 @@ describe('FirestoreCollectionJobRunner', () => {
     expect(db.commits.map((commit) => commit.length)).toEqual([1, 1, 1]);
   });
 
+  it('retries oversized copy commits as smaller batches', async () => {
+    const db = new FakeFirestore(
+      { orders: ['orders/order_1', 'orders/order_2', 'orders/order_3', 'orders/order_4'] },
+      {},
+      { rejectCommitsOver: 2 },
+    );
+    const runner = new FirestoreCollectionJobRunner(provider(db), { tempDirectory: '/tmp' });
+
+    await runner.run(copyJob('overwrite'), neverCancelled(), { update: vi.fn() });
+
+    expect(db.commits).toEqual([
+      ['orders_copy/order_1', 'orders_copy/order_2'],
+      ['orders_copy/order_3', 'orders_copy/order_4'],
+    ]);
+  });
+
   it('imports encoded JSONL with batched collision checks', async () => {
     const dir = await makeTempDir();
     const filePath = join(dir, 'import.jsonl');
@@ -154,6 +170,7 @@ class FakeFirestore {
   constructor(
     private readonly docsByCollection: Record<string, string[]>,
     private readonly dataByPath: Record<string, Record<string, unknown>> = {},
+    private readonly options: { readonly rejectCommitsOver?: number; } = {},
   ) {
     this.existingPaths = new Set(Object.values(docsByCollection).flat());
   }
@@ -162,6 +179,9 @@ class FakeFirestore {
     const paths: string[] = [];
     return {
       commit: async () => {
+        if (this.options.rejectCommitsOver && paths.length > this.options.rejectCommitsOver) {
+          throw new Error('Request payload size exceeds the limit: 11534336 bytes.');
+        }
         this.commits.push([...paths]);
       },
       delete: (ref: { readonly path: string; }) => {

--- a/apps/desktop/src/main/jobs/firestore-collection-job-runner.test.ts
+++ b/apps/desktop/src/main/jobs/firestore-collection-job-runner.test.ts
@@ -101,6 +101,18 @@ describe('FirestoreCollectionJobRunner', () => {
     ]);
   });
 
+  it('reports the document path when one copy write exceeds request payload size', async () => {
+    const db = new FakeFirestore(
+      { orders: ['orders/order_1'] },
+      {},
+      { rejectCommitsOver: 0 },
+    );
+    const runner = new FirestoreCollectionJobRunner(provider(db), { tempDirectory: '/tmp' });
+
+    await expect(runner.run(copyJob('overwrite'), neverCancelled(), { update: vi.fn() }))
+      .rejects.toThrow('orders_copy/order_1');
+  });
+
   it('imports encoded JSONL with batched collision checks', async () => {
     const dir = await makeTempDir();
     const filePath = join(dir, 'import.jsonl');
@@ -179,7 +191,10 @@ class FakeFirestore {
     const paths: string[] = [];
     return {
       commit: async () => {
-        if (this.options.rejectCommitsOver && paths.length > this.options.rejectCommitsOver) {
+        if (
+          this.options.rejectCommitsOver !== undefined
+          && paths.length > this.options.rejectCommitsOver
+        ) {
           throw new Error('Request payload size exceeds the limit: 11534336 bytes.');
         }
         this.commits.push([...paths]);

--- a/apps/desktop/src/main/jobs/firestore-collection-job-runner.ts
+++ b/apps/desktop/src/main/jobs/firestore-collection-job-runner.ts
@@ -27,7 +27,9 @@ import { basename, dirname, join } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 
 const PAGE_SIZE = 250;
+const DEFAULT_WRITE_BATCH_MAX_BYTES = 8 * 1024 * 1024;
 const WRITE_BATCH_LIMIT = 500;
+const WRITE_OPERATION_OVERHEAD_BYTES = 512;
 
 type MutableProgress = {
   -readonly [K in keyof BackgroundJobProgress]: BackgroundJobProgress[K];
@@ -35,6 +37,7 @@ type MutableProgress = {
 
 export interface FirestoreCollectionJobRunnerOptions {
   readonly tempDirectory: string;
+  readonly writeBatchMaxBytes?: number | undefined;
 }
 
 export interface JobCancellationSignal {
@@ -103,7 +106,7 @@ export class FirestoreCollectionJobRunner {
     assertFirestoreCollectionPath(request.targetCollectionPath);
     const sourceDb = await this.firestore(request.sourceConnectionId);
     const targetDb = await this.firestore(request.targetConnectionId);
-    const batcher = new BatchWriter(targetDb);
+    const batcher = new BatchWriter(targetDb, this.writeBatchMaxBytes());
     const progress = progressCounter();
     let chunk: QueryDocumentSnapshot[] = [];
 
@@ -153,7 +156,7 @@ export class FirestoreCollectionJobRunner {
   ): Promise<void> {
     assertFirestoreCollectionPath(request.collectionPath);
     const db = await this.firestore(request.connectionId);
-    const batcher = new BatchWriter(db);
+    const batcher = new BatchWriter(db, this.writeBatchMaxBytes());
     const progress = progressCounter();
     for await (
       const doc of streamCollectionDocumentsForDelete(
@@ -166,9 +169,8 @@ export class FirestoreCollectionJobRunner {
       assertNotCancelled(signal);
       progress.read += 1;
       progress.currentPath = doc.ref.path;
-      batcher.delete(doc.ref.path);
+      await batcher.delete(doc.ref.path, signal);
       progress.deleted += 1;
-      await commitIfFull(batcher, signal);
       await sink.update(progress);
     }
     assertNotCancelled(signal);
@@ -282,7 +284,7 @@ export class FirestoreCollectionJobRunner {
   ): Promise<void> {
     assertFirestoreCollectionPath(request.targetCollectionPath);
     const db = await this.firestore(request.connectionId);
-    const batcher = new BatchWriter(db);
+    const batcher = new BatchWriter(db, this.writeBatchMaxBytes());
     const progress = progressCounter();
     const input = createReadStream(request.filePath, { encoding: 'utf8' });
     const lines = createInterface({ crlfDelay: Infinity, input });
@@ -310,6 +312,10 @@ export class FirestoreCollectionJobRunner {
 
   private async firestore(connectionId: string): Promise<Firestore> {
     return (await this.provider.getFirestoreConnection(connectionId)).db;
+  }
+
+  private writeBatchMaxBytes(): number {
+    return this.options.writeBatchMaxBytes ?? DEFAULT_WRITE_BATCH_MAX_BYTES;
   }
 
   private async copyDocumentChunk(
@@ -343,9 +349,14 @@ export class FirestoreCollectionJobRunner {
         await sink.update(progress);
         continue;
       }
-      batcher.set(targetPath, decodeAdminData(targetDb, encodeAdminData(doc.data())));
+      const encodedData = encodeAdminData(doc.data());
+      await batcher.set(
+        targetPath,
+        decodeAdminData(targetDb, encodedData),
+        estimateSetOperationBytes(targetPath, encodedData),
+        signal,
+      );
       progress.written += 1;
-      await commitIfFull(batcher, signal);
       await sink.update(progress);
     }
     // oxlint-enable no-await-in-loop
@@ -355,14 +366,21 @@ export class FirestoreCollectionJobRunner {
 class BatchWriter {
   private batch: WriteBatch;
   private count = 0;
+  private estimatedBytes = 0;
 
-  constructor(private readonly db: Firestore) {
+  constructor(
+    private readonly db: Firestore,
+    private readonly maxBytes: number,
+  ) {
     this.batch = db.batch();
   }
 
-  delete(path: string): void {
+  async delete(path: string, signal: JobCancellationSignal): Promise<void> {
+    const operationBytes = estimateDeleteOperationBytes(path);
+    await this.commitBeforeOverflow(operationBytes, signal);
     this.batch.delete(this.db.doc(path));
     this.count += 1;
+    this.estimatedBytes += operationBytes;
   }
 
   async commit(): Promise<void> {
@@ -370,23 +388,35 @@ class BatchWriter {
     const batch = this.batch;
     this.batch = this.db.batch();
     this.count = 0;
+    this.estimatedBytes = 0;
     await batch.commit();
   }
 
-  isFull(): boolean {
-    return this.count >= WRITE_BATCH_LIMIT;
-  }
-
-  set(path: string, data: DocumentData): void {
+  async set(
+    path: string,
+    data: DocumentData,
+    operationBytes: number,
+    signal: JobCancellationSignal,
+  ): Promise<void> {
+    await this.commitBeforeOverflow(operationBytes, signal);
     this.batch.set(this.db.doc(path), data);
     this.count += 1;
+    this.estimatedBytes += operationBytes;
   }
-}
 
-async function commitIfFull(batcher: BatchWriter, signal: JobCancellationSignal): Promise<void> {
-  if (!batcher.isFull()) return;
-  assertNotCancelled(signal);
-  await batcher.commit();
+  private async commitBeforeOverflow(
+    operationBytes: number,
+    signal: JobCancellationSignal,
+  ): Promise<void> {
+    if (
+      this.count === 0
+      || (this.count < WRITE_BATCH_LIMIT && this.estimatedBytes + operationBytes <= this.maxBytes)
+    ) {
+      return;
+    }
+    assertNotCancelled(signal);
+    await this.commit();
+  }
 }
 
 async function* streamCollectionDocuments(
@@ -471,9 +501,13 @@ async function writeImportChunk(
       await sink.update(progress);
       continue;
     }
-    batcher.set(item.targetPath, decodeAdminData(db, item.data));
+    await batcher.set(
+      item.targetPath,
+      decodeAdminData(db, item.data),
+      estimateSetOperationBytes(item.targetPath, item.data),
+      signal,
+    );
     progress.written += 1;
-    await commitIfFull(batcher, signal);
     await sink.update(progress);
   }
   // oxlint-enable no-await-in-loop
@@ -538,6 +572,15 @@ function progressCounter(): MutableProgress {
     skipped: 0,
     written: 0,
   };
+}
+
+function estimateDeleteOperationBytes(path: string): number {
+  return WRITE_OPERATION_OVERHEAD_BYTES + Buffer.byteLength(path, 'utf8');
+}
+
+function estimateSetOperationBytes(path: string, data: unknown): number {
+  return estimateDeleteOperationBytes(path)
+    + Buffer.byteLength(JSON.stringify(data) ?? 'null', 'utf8');
 }
 
 function assertNotCancelled(signal: JobCancellationSignal): void {

--- a/apps/desktop/src/main/jobs/firestore-collection-job-runner.ts
+++ b/apps/desktop/src/main/jobs/firestore-collection-job-runner.ts
@@ -1,6 +1,7 @@
 import {
   assertFirestoreCollectionPath,
   assertFirestoreDocumentPath,
+  estimateFirestoreDocumentBytes,
   firestorePathParts,
 } from '@firebase-desk/repo-contracts';
 import type {
@@ -28,7 +29,6 @@ import { createInterface } from 'node:readline/promises';
 const PAGE_SIZE = 250;
 const DEFAULT_WRITE_BATCH_MAX_BYTES = 8 * 1024 * 1024;
 const WRITE_BATCH_LIMIT = 500;
-const WRITE_FIELD_OVERHEAD_BYTES = 32;
 const WRITE_OPERATION_OVERHEAD_BYTES = 512;
 
 type MutableProgress = {
@@ -608,31 +608,8 @@ function estimateDeleteOperationBytes(path: string): number {
   return WRITE_OPERATION_OVERHEAD_BYTES + Buffer.byteLength(path, 'utf8');
 }
 
-function estimateSetOperationBytes(path: string, data: unknown): number {
-  return estimateDeleteOperationBytes(path) + estimateValueBytes(data);
-}
-
-function estimateValueBytes(value: unknown): number {
-  if (value === null || value === undefined) return 4;
-  if (typeof value === 'string') return Buffer.byteLength(value, 'utf8') + 2;
-  if (typeof value === 'number') return 16;
-  if (typeof value === 'boolean') return 5;
-  if (Array.isArray(value)) {
-    return WRITE_FIELD_OVERHEAD_BYTES
-      + value.reduce((total, item) => total + estimateValueBytes(item), 0);
-  }
-  if (isPlainObject(value)) {
-    return WRITE_FIELD_OVERHEAD_BYTES
-      + Object.entries(value).reduce(
-        (total, [key, item]) =>
-          total
-          + Buffer.byteLength(key, 'utf8')
-          + WRITE_FIELD_OVERHEAD_BYTES
-          + estimateValueBytes(item),
-        0,
-      );
-  }
-  return WRITE_FIELD_OVERHEAD_BYTES;
+function estimateSetOperationBytes(path: string, data: Record<string, unknown>): number {
+  return estimateDeleteOperationBytes(path) + estimateFirestoreDocumentBytes(data);
 }
 
 function isRequestPayloadSizeError(error: unknown): error is Error {

--- a/apps/desktop/src/main/jobs/firestore-collection-job-runner.ts
+++ b/apps/desktop/src/main/jobs/firestore-collection-job-runner.ts
@@ -18,7 +18,6 @@ import {
   FieldPath,
   type Firestore,
   type QueryDocumentSnapshot,
-  type WriteBatch,
 } from 'firebase-admin/firestore';
 import { once } from 'node:events';
 import { createReadStream, createWriteStream } from 'node:fs';
@@ -34,6 +33,10 @@ const WRITE_OPERATION_OVERHEAD_BYTES = 512;
 type MutableProgress = {
   -readonly [K in keyof BackgroundJobProgress]: BackgroundJobProgress[K];
 };
+
+type BatchOperation =
+  | { readonly path: string; readonly type: 'delete'; }
+  | { readonly data: DocumentData; readonly path: string; readonly type: 'set'; };
 
 export interface FirestoreCollectionJobRunnerOptions {
   readonly tempDirectory: string;
@@ -364,32 +367,27 @@ export class FirestoreCollectionJobRunner {
 }
 
 class BatchWriter {
-  private batch: WriteBatch;
-  private count = 0;
+  private pendingOperations: BatchOperation[] = [];
   private estimatedBytes = 0;
 
   constructor(
     private readonly db: Firestore,
     private readonly maxBytes: number,
-  ) {
-    this.batch = db.batch();
-  }
+  ) {}
 
   async delete(path: string, signal: JobCancellationSignal): Promise<void> {
     const operationBytes = estimateDeleteOperationBytes(path);
     await this.commitBeforeOverflow(operationBytes, signal);
-    this.batch.delete(this.db.doc(path));
-    this.count += 1;
+    this.pendingOperations.push({ path, type: 'delete' });
     this.estimatedBytes += operationBytes;
   }
 
   async commit(): Promise<void> {
-    if (this.count === 0) return;
-    const batch = this.batch;
-    this.batch = this.db.batch();
-    this.count = 0;
+    if (this.pendingOperations.length === 0) return;
+    const operations = this.pendingOperations;
+    this.pendingOperations = [];
     this.estimatedBytes = 0;
-    await batch.commit();
+    await this.commitOperations(operations);
   }
 
   async set(
@@ -399,9 +397,31 @@ class BatchWriter {
     signal: JobCancellationSignal,
   ): Promise<void> {
     await this.commitBeforeOverflow(operationBytes, signal);
-    this.batch.set(this.db.doc(path), data);
-    this.count += 1;
+    this.pendingOperations.push({ data, path, type: 'set' });
     this.estimatedBytes += operationBytes;
+  }
+
+  private async commitOperations(operations: ReadonlyArray<BatchOperation>): Promise<void> {
+    try {
+      await this.commitOperationBatch(operations);
+    } catch (error) {
+      if (!isRequestPayloadSizeError(error) || operations.length === 1) throw error;
+      const splitIndex = Math.ceil(operations.length / 2);
+      await this.commitOperations(operations.slice(0, splitIndex));
+      await this.commitOperations(operations.slice(splitIndex));
+    }
+  }
+
+  private async commitOperationBatch(operations: ReadonlyArray<BatchOperation>): Promise<void> {
+    const batch = this.db.batch();
+    for (const operation of operations) {
+      if (operation.type === 'delete') {
+        batch.delete(this.db.doc(operation.path));
+        continue;
+      }
+      batch.set(this.db.doc(operation.path), operation.data);
+    }
+    await batch.commit();
   }
 
   private async commitBeforeOverflow(
@@ -409,8 +429,9 @@ class BatchWriter {
     signal: JobCancellationSignal,
   ): Promise<void> {
     if (
-      this.count === 0
-      || (this.count < WRITE_BATCH_LIMIT && this.estimatedBytes + operationBytes <= this.maxBytes)
+      this.pendingOperations.length === 0
+      || (this.pendingOperations.length < WRITE_BATCH_LIMIT
+        && this.estimatedBytes + operationBytes <= this.maxBytes)
     ) {
       return;
     }
@@ -581,6 +602,11 @@ function estimateDeleteOperationBytes(path: string): number {
 function estimateSetOperationBytes(path: string, data: unknown): number {
   return estimateDeleteOperationBytes(path)
     + Buffer.byteLength(JSON.stringify(data) ?? 'null', 'utf8');
+}
+
+function isRequestPayloadSizeError(error: unknown): boolean {
+  return error instanceof Error
+    && /request payload size exceeds the limit/i.test(error.message);
 }
 
 function assertNotCancelled(signal: JobCancellationSignal): void {

--- a/apps/desktop/src/main/jobs/firestore-collection-job-runner.ts
+++ b/apps/desktop/src/main/jobs/firestore-collection-job-runner.ts
@@ -28,6 +28,7 @@ import { createInterface } from 'node:readline/promises';
 const PAGE_SIZE = 250;
 const DEFAULT_WRITE_BATCH_MAX_BYTES = 8 * 1024 * 1024;
 const WRITE_BATCH_LIMIT = 500;
+const WRITE_FIELD_OVERHEAD_BYTES = 32;
 const WRITE_OPERATION_OVERHEAD_BYTES = 512;
 
 type MutableProgress = {
@@ -608,8 +609,30 @@ function estimateDeleteOperationBytes(path: string): number {
 }
 
 function estimateSetOperationBytes(path: string, data: unknown): number {
-  return estimateDeleteOperationBytes(path)
-    + Buffer.byteLength(JSON.stringify(data) ?? 'null', 'utf8');
+  return estimateDeleteOperationBytes(path) + estimateValueBytes(data);
+}
+
+function estimateValueBytes(value: unknown): number {
+  if (value === null || value === undefined) return 4;
+  if (typeof value === 'string') return Buffer.byteLength(value, 'utf8') + 2;
+  if (typeof value === 'number') return 16;
+  if (typeof value === 'boolean') return 5;
+  if (Array.isArray(value)) {
+    return WRITE_FIELD_OVERHEAD_BYTES
+      + value.reduce((total, item) => total + estimateValueBytes(item), 0);
+  }
+  if (isPlainObject(value)) {
+    return WRITE_FIELD_OVERHEAD_BYTES
+      + Object.entries(value).reduce(
+        (total, [key, item]) =>
+          total
+          + Buffer.byteLength(key, 'utf8')
+          + WRITE_FIELD_OVERHEAD_BYTES
+          + estimateValueBytes(item),
+        0,
+      );
+  }
+  return WRITE_FIELD_OVERHEAD_BYTES;
 }
 
 function isRequestPayloadSizeError(error: unknown): error is Error {

--- a/apps/desktop/src/main/jobs/firestore-collection-job-runner.ts
+++ b/apps/desktop/src/main/jobs/firestore-collection-job-runner.ts
@@ -609,7 +609,9 @@ function estimateDeleteOperationBytes(path: string): number {
 }
 
 function estimateSetOperationBytes(path: string, data: Record<string, unknown>): number {
-  return estimateDeleteOperationBytes(path) + estimateFirestoreDocumentBytes(data);
+  return estimateDeleteOperationBytes(path) + estimateFirestoreDocumentBytes(data, {
+    documentPath: path,
+  });
 }
 
 function isRequestPayloadSizeError(error: unknown): error is Error {

--- a/apps/desktop/src/main/jobs/firestore-collection-job-runner.ts
+++ b/apps/desktop/src/main/jobs/firestore-collection-job-runner.ts
@@ -405,7 +405,15 @@ class BatchWriter {
     try {
       await this.commitOperationBatch(operations);
     } catch (error) {
-      if (!isRequestPayloadSizeError(error) || operations.length === 1) throw error;
+      if (!isRequestPayloadSizeError(error)) throw error;
+      if (operations.length === 1) {
+        throw new Error(
+          `Firestore write exceeds request payload limit for ${
+            operations[0]?.path ?? 'unknown document'
+          }. ${error.message}`,
+          { cause: error },
+        );
+      }
       const splitIndex = Math.ceil(operations.length / 2);
       await this.commitOperations(operations.slice(0, splitIndex));
       await this.commitOperations(operations.slice(splitIndex));
@@ -604,7 +612,7 @@ function estimateSetOperationBytes(path: string, data: unknown): number {
     + Buffer.byteLength(JSON.stringify(data) ?? 'null', 'utf8');
 }
 
-function isRequestPayloadSizeError(error: unknown): boolean {
+function isRequestPayloadSizeError(error: unknown): error is Error {
   return error instanceof Error
     && /request payload size exceeds the limit/i.test(error.message);
 }

--- a/apps/desktop/src/main/main-window-constants.ts
+++ b/apps/desktop/src/main/main-window-constants.ts
@@ -1,0 +1,4 @@
+export const MAIN_WINDOW_DEFAULT_HEIGHT = 820;
+export const MAIN_WINDOW_DEFAULT_WIDTH = 1280;
+export const MAIN_WINDOW_MIN_HEIGHT = 640;
+export const MAIN_WINDOW_MIN_WIDTH = 960;

--- a/apps/desktop/src/main/native-app-policy.test.ts
+++ b/apps/desktop/src/main/native-app-policy.test.ts
@@ -1,0 +1,96 @@
+import type { BackgroundJob } from '@firebase-desk/repo-contracts/jobs';
+import { describe, expect, it } from 'vitest';
+import {
+  backgroundJobNotificationForEvent,
+  nativeContextMenuActions,
+  shouldOpenExternally,
+} from './native-app-policy.ts';
+
+describe('native app policy', () => {
+  it('opens only external links outside the app shell', () => {
+    expect(shouldOpenExternally('https://firebase.google.com/docs', 'file:///app/index.html'))
+      .toBe(true);
+    expect(shouldOpenExternally('https://docs.example/path', 'https://app.example/shell'))
+      .toBe(true);
+    expect(shouldOpenExternally('https://app.example/next', 'https://app.example/shell'))
+      .toBe(false);
+    expect(shouldOpenExternally('mailto:team@example.com', 'https://app.example/shell')).toBe(true);
+    expect(shouldOpenExternally('file:///tmp/data.json', 'file:///app/index.html')).toBe(false);
+  });
+
+  it('uses native edit actions for editable context menus', () => {
+    expect(nativeContextMenuActions({ isEditable: true }, false)).toEqual([
+      'cut',
+      'copy',
+      'paste',
+      'paste-and-match-style',
+      'separator',
+      'delete',
+      'select-all',
+    ]);
+  });
+
+  it('keeps inspect actions development-only', () => {
+    expect(nativeContextMenuActions({ isEditable: false, selectionText: 'abc' }, false)).toEqual([
+      'copy',
+    ]);
+    expect(nativeContextMenuActions({ isEditable: false, selectionText: 'abc' }, true)).toEqual([
+      'copy',
+      'separator',
+      'inspect',
+    ]);
+  });
+
+  it('creates notifications only for final background job updates', () => {
+    expect(backgroundJobNotificationForEvent({ job: job('running'), type: 'job-updated' })).toBe(
+      null,
+    );
+    expect(backgroundJobNotificationForEvent({ job: job('succeeded'), type: 'job-added' })).toBe(
+      null,
+    );
+    expect(backgroundJobNotificationForEvent({ job: job('succeeded'), type: 'job-updated' }))
+      .toEqual({
+        body: 'Exported 2 rows.',
+        jobId: 'job-1',
+        title: 'Export collection succeeded',
+      });
+    expect(
+      backgroundJobNotificationForEvent({
+        job: { ...job('failed'), error: { message: 'Permission denied' } },
+        type: 'job-updated',
+      }),
+    ).toMatchObject({
+      body: 'Permission denied',
+      title: 'Export collection failed',
+    });
+    expect(
+      backgroundJobNotificationForEvent({
+        job: { ...job('failed'), acknowledgedAt: '2026-05-01T00:02:00.000Z' },
+        type: 'job-updated',
+      }),
+    ).toBe(null);
+  });
+});
+
+function job(status: BackgroundJob['status']): BackgroundJob {
+  return {
+    createdAt: '2026-05-01T00:00:00.000Z',
+    id: 'job-1',
+    progress: { deleted: 0, failed: 0, read: 2, skipped: 0, written: 0 },
+    request: {
+      collectionPath: 'orders',
+      connectionId: 'demo',
+      encoding: 'encoded',
+      filePath: '/tmp/orders.jsonl',
+      format: 'jsonl',
+      includeSubcollections: false,
+      type: 'firestore.exportCollection',
+    },
+    status,
+    summary: 'Exported 2 rows.',
+    ...(status === 'running' ? {} : { finishedAt: '2026-05-01T00:01:00.000Z' }),
+    title: 'Export collection',
+    type: 'firestore.exportCollection',
+    updatedAt: '2026-05-01T00:00:00.000Z',
+  };
+}

--- a/apps/desktop/src/main/native-app-policy.test.ts
+++ b/apps/desktop/src/main/native-app-policy.test.ts
@@ -2,6 +2,7 @@ import type { BackgroundJob } from '@firebase-desk/repo-contracts/jobs';
 import { describe, expect, it } from 'vitest';
 import {
   backgroundJobNotificationForEvent,
+  isInternalAppNavigation,
   nativeContextMenuActions,
   shouldOpenExternally,
 } from './native-app-policy.ts';
@@ -16,6 +17,17 @@ describe('native app policy', () => {
       .toBe(false);
     expect(shouldOpenExternally('mailto:team@example.com', 'https://app.example/shell')).toBe(true);
     expect(shouldOpenExternally('file:///tmp/data.json', 'file:///app/index.html')).toBe(false);
+  });
+
+  it('allows only app shell navigation internally', () => {
+    expect(isInternalAppNavigation('file:///app/index.html#/settings', 'file:///app/index.html'))
+      .toBe(true);
+    expect(isInternalAppNavigation('file:///tmp/data.json', 'file:///app/index.html')).toBe(
+      false,
+    );
+    expect(isInternalAppNavigation('https://app.example/next', 'https://app.example/shell'))
+      .toBe(true);
+    expect(isInternalAppNavigation('about:blank', 'https://app.example/shell')).toBe(false);
   });
 
   it('uses native edit actions for editable context menus', () => {

--- a/apps/desktop/src/main/native-app-policy.ts
+++ b/apps/desktop/src/main/native-app-policy.ts
@@ -1,0 +1,120 @@
+import type { BackgroundJobEvent, BackgroundJobStatus } from '@firebase-desk/repo-contracts/jobs';
+
+export type NativeContextMenuAction =
+  | 'copy'
+  | 'cut'
+  | 'delete'
+  | 'inspect'
+  | 'open-link'
+  | 'paste'
+  | 'paste-and-match-style'
+  | 'separator'
+  | 'select-all';
+
+export interface NativeContextMenuParams {
+  readonly isEditable: boolean;
+  readonly linkURL?: string | undefined;
+  readonly selectionText?: string | undefined;
+}
+
+export interface JobNotification {
+  readonly body: string;
+  readonly jobId: string;
+  readonly title: string;
+}
+
+const externalProtocols = new Set(['http:', 'https:', 'mailto:']);
+const finalJobStatuses = new Set<BackgroundJobStatus>([
+  'cancelled',
+  'failed',
+  'interrupted',
+  'succeeded',
+]);
+
+export function shouldOpenExternally(targetUrl: string, currentUrl: string): boolean {
+  const target = parseUrl(targetUrl);
+  if (!target || !externalProtocols.has(target.protocol)) return false;
+  if (target.protocol === 'mailto:') return true;
+
+  const current = parseUrl(currentUrl);
+  if (!current || !externalProtocols.has(current.protocol)) return true;
+  return target.origin !== current.origin;
+}
+
+export function nativeContextMenuActions(
+  params: NativeContextMenuParams,
+  isDevelopment: boolean,
+): ReadonlyArray<NativeContextMenuAction> {
+  const actions: NativeContextMenuAction[] = [];
+
+  if (params.linkURL && canOpenExternalUrl(params.linkURL)) actions.push('open-link', 'separator');
+
+  if (params.isEditable) {
+    actions.push(
+      'cut',
+      'copy',
+      'paste',
+      'paste-and-match-style',
+      'separator',
+      'delete',
+      'select-all',
+    );
+  } else if (params.selectionText?.trim()) {
+    actions.push('copy');
+  }
+
+  if (isDevelopment) {
+    if (actions.length > 0 && actions.at(-1) !== 'separator') actions.push('separator');
+    actions.push('inspect');
+  }
+
+  return trimSeparators(actions);
+}
+
+export function backgroundJobNotificationForEvent(
+  event: BackgroundJobEvent,
+): JobNotification | null {
+  if (event.type !== 'job-updated' || !finalJobStatuses.has(event.job.status)) return null;
+  if (!event.job.finishedAt || event.job.acknowledgedAt) return null;
+  const outcome = jobOutcome(event.job.status);
+  return {
+    body: event.job.error?.message ?? event.job.summary ?? outcome,
+    jobId: event.job.id,
+    title: `${event.job.title} ${outcome}`,
+  };
+}
+
+function jobOutcome(status: BackgroundJobStatus): string {
+  if (status === 'succeeded') return 'succeeded';
+  if (status === 'failed') return 'failed';
+  if (status === 'cancelled') return 'cancelled';
+  if (status === 'interrupted') return 'interrupted';
+  return status;
+}
+
+function parseUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+function canOpenExternalUrl(value: string): boolean {
+  const url = parseUrl(value);
+  return Boolean(url && externalProtocols.has(url.protocol));
+}
+
+function trimSeparators(
+  actions: ReadonlyArray<NativeContextMenuAction>,
+): ReadonlyArray<NativeContextMenuAction> {
+  const trimmed = [...actions];
+  while (trimmed[0] === 'separator') trimmed.shift();
+  while (trimmed.at(-1) === 'separator') trimmed.pop();
+  for (let index = trimmed.length - 1; index > 0; index -= 1) {
+    if (trimmed[index] === 'separator' && trimmed[index - 1] === 'separator') {
+      trimmed.splice(index, 1);
+    }
+  }
+  return trimmed;
+}

--- a/apps/desktop/src/main/native-app-policy.ts
+++ b/apps/desktop/src/main/native-app-policy.ts
@@ -36,9 +36,21 @@ export function shouldOpenExternally(targetUrl: string, currentUrl: string): boo
   if (!target || !externalProtocols.has(target.protocol)) return false;
   if (target.protocol === 'mailto:') return true;
 
+  return !isInternalAppNavigation(targetUrl, currentUrl);
+}
+
+export function isInternalAppNavigation(targetUrl: string, currentUrl: string): boolean {
+  const target = parseUrl(targetUrl);
   const current = parseUrl(currentUrl);
-  if (!current || !externalProtocols.has(current.protocol)) return true;
-  return target.origin !== current.origin;
+  if (!target || !current) return false;
+  if (target.protocol === 'file:' && current.protocol === 'file:') {
+    return target.pathname === current.pathname;
+  }
+  if (!externalProtocols.has(target.protocol) || !externalProtocols.has(current.protocol)) {
+    return false;
+  }
+  if (target.protocol === 'mailto:' || current.protocol === 'mailto:') return false;
+  return target.origin === current.origin;
 }
 
 export function nativeContextMenuActions(

--- a/apps/desktop/src/main/native-app.test.ts
+++ b/apps/desktop/src/main/native-app.test.ts
@@ -1,0 +1,102 @@
+import type { BackgroundJob } from '@firebase-desk/repo-contracts/jobs';
+import { describe, expect, it, vi } from 'vitest';
+import { createBackgroundJobNotifier } from './native-app.ts';
+
+type ShowNotification = NonNullable<
+  Parameters<typeof createBackgroundJobNotifier>[0]
+>['showNotification'];
+
+vi.mock('electron', () => ({
+  app: { isPackaged: true, name: 'Firebase Desk' },
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => []),
+    getFocusedWindow: vi.fn(() => null),
+  },
+  Menu: { buildFromTemplate: vi.fn(), setApplicationMenu: vi.fn() },
+  nativeTheme: { themeSource: 'system' },
+  Notification: { isSupported: vi.fn(() => true) },
+  shell: { openExternal: vi.fn() },
+}));
+
+describe('background job notifier', () => {
+  it('dedupes final job notifications', () => {
+    const showNotification = vi.fn<ShowNotification>();
+    const notify = notifier(showNotification);
+
+    notify({ job: job('job-1'), type: 'job-updated' });
+    notify({ job: job('job-1'), type: 'job-updated' });
+
+    expect(showNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('forgets removed jobs', () => {
+    const showNotification = vi.fn<ShowNotification>();
+    const notify = notifier(showNotification);
+
+    notify({ job: job('job-1'), type: 'job-updated' });
+    notify({ id: 'job-1', type: 'job-removed' });
+    notify({ job: job('job-1'), type: 'job-updated' });
+
+    expect(showNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it('forgets acknowledged jobs', () => {
+    const showNotification = vi.fn<ShowNotification>();
+    const notify = notifier(showNotification);
+
+    notify({ job: job('job-1'), type: 'job-updated' });
+    notify({
+      job: { ...job('job-1'), acknowledgedAt: '2026-05-01T00:02:00.000Z' },
+      type: 'job-updated',
+    });
+    notify({ job: job('job-1'), type: 'job-updated' });
+
+    expect(showNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it('bounds remembered job ids', () => {
+    const showNotification = vi.fn<ShowNotification>();
+    const notify = notifier(showNotification);
+
+    for (let index = 0; index <= 500; index += 1) {
+      notify({ job: job(`job-${index}`), type: 'job-updated' });
+    }
+    notify({ job: job('job-0'), type: 'job-updated' });
+
+    expect(showNotification).toHaveBeenCalledTimes(502);
+  });
+});
+
+function notifier(
+  showNotification: ShowNotification,
+): ReturnType<typeof createBackgroundJobNotifier> {
+  return createBackgroundJobNotifier({
+    focusApp: vi.fn(),
+    isAppFocused: () => false,
+    isNotificationSupported: () => true,
+    showNotification,
+  });
+}
+
+function job(id: string): BackgroundJob {
+  return {
+    createdAt: '2026-05-01T00:00:00.000Z',
+    finishedAt: '2026-05-01T00:01:00.000Z',
+    id,
+    progress: { deleted: 0, failed: 0, read: 2, skipped: 0, written: 0 },
+    request: {
+      collectionPath: 'orders',
+      connectionId: 'demo',
+      encoding: 'encoded',
+      filePath: '/tmp/orders.jsonl',
+      format: 'jsonl',
+      includeSubcollections: false,
+      type: 'firestore.exportCollection',
+    },
+    status: 'succeeded',
+    summary: 'Exported 2 rows.',
+    title: 'Export collection',
+    type: 'firestore.exportCollection',
+    updatedAt: '2026-05-01T00:00:00.000Z',
+  };
+}

--- a/apps/desktop/src/main/native-app.test.ts
+++ b/apps/desktop/src/main/native-app.test.ts
@@ -1,6 +1,7 @@
 import type { BackgroundJob } from '@firebase-desk/repo-contracts/jobs';
-import { describe, expect, it, vi } from 'vitest';
-import { createBackgroundJobNotifier } from './native-app.ts';
+import { type BrowserWindow, shell } from 'electron';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createBackgroundJobNotifier, installNativeWindowBehavior } from './native-app.ts';
 
 type ShowNotification = NonNullable<
   Parameters<typeof createBackgroundJobNotifier>[0]
@@ -17,6 +18,38 @@ vi.mock('electron', () => ({
   Notification: { isSupported: vi.fn(() => true) },
   shell: { openExternal: vi.fn() },
 }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('native window behavior', () => {
+  it('denies popups while opening external popup URLs in the browser', () => {
+    const externalUrl = 'https://firebase.google.com/docs';
+    const harness = nativeWindowHarness('file:///app/index.html');
+    vi.mocked(shell.openExternal).mockResolvedValue(undefined);
+
+    installNativeWindowBehavior(harness.window);
+
+    expect(harness.openWindow(externalUrl)).toEqual({ action: 'deny' });
+    expect(harness.openWindow('file:///app/index.html#/settings')).toEqual({ action: 'deny' });
+    expect(shell.openExternal).toHaveBeenCalledWith(externalUrl);
+  });
+
+  it('blocks non-app navigations and opens external navigations in the browser', () => {
+    const externalUrl = 'https://firebase.google.com/docs';
+    const harness = nativeWindowHarness('file:///app/index.html');
+    vi.mocked(shell.openExternal).mockResolvedValue(undefined);
+
+    installNativeWindowBehavior(harness.window);
+
+    expect(harness.navigate('file:///app/index.html#/settings').preventDefault).not
+      .toHaveBeenCalled();
+    expect(harness.navigate('about:blank').preventDefault).toHaveBeenCalled();
+    expect(harness.navigate(externalUrl).preventDefault).toHaveBeenCalled();
+    expect(shell.openExternal).toHaveBeenCalledWith(externalUrl);
+  });
+});
 
 describe('background job notifier', () => {
   it('dedupes final job notifications', () => {
@@ -66,6 +99,44 @@ describe('background job notifier', () => {
     expect(showNotification).toHaveBeenCalledTimes(502);
   });
 });
+
+type WindowOpenHandler = Parameters<BrowserWindow['webContents']['setWindowOpenHandler']>[0];
+type WillNavigateHandler = (
+  event: { readonly preventDefault: () => void; },
+  url: string,
+) => void;
+
+function nativeWindowHarness(currentUrl: string): {
+  readonly navigate: (url: string) => { readonly preventDefault: ReturnType<typeof vi.fn>; };
+  readonly openWindow: (url: string) => ReturnType<WindowOpenHandler>;
+  readonly window: BrowserWindow;
+} {
+  let openHandler: WindowOpenHandler | null = null;
+  let willNavigateHandler: WillNavigateHandler | null = null;
+  const webContents = {
+    getURL: vi.fn(() => currentUrl),
+    inspectElement: vi.fn(),
+    on: vi.fn((event: string, handler: WillNavigateHandler) => {
+      if (event === 'will-navigate') willNavigateHandler = handler;
+    }),
+    setWindowOpenHandler: vi.fn((handler: WindowOpenHandler) => {
+      openHandler = handler;
+    }),
+  };
+  return {
+    navigate: (url) => {
+      if (!willNavigateHandler) throw new Error('will-navigate handler missing');
+      const event = { preventDefault: vi.fn() };
+      willNavigateHandler(event, url);
+      return event;
+    },
+    openWindow: (url) => {
+      if (!openHandler) throw new Error('window open handler missing');
+      return openHandler({ url } as Parameters<WindowOpenHandler>[0]);
+    },
+    window: { webContents } as unknown as BrowserWindow,
+  };
+}
 
 function notifier(
   showNotification: ShowNotification,

--- a/apps/desktop/src/main/native-app.ts
+++ b/apps/desktop/src/main/native-app.ts
@@ -33,6 +33,8 @@ interface BackgroundJobNotifierDeps {
   ) => void;
 }
 
+const MAX_NOTIFIED_BACKGROUND_JOB_IDS = 500;
+
 export function installNativeAppBehavior(): void {
   nativeTheme.themeSource = 'system';
   Menu.setApplicationMenu(Menu.buildFromTemplate(applicationMenuTemplate()));
@@ -81,12 +83,27 @@ export function createBackgroundJobNotifier(
 ): (event: BackgroundJobEvent) => void {
   const notifiedJobIds = new Set<string>();
   return (event) => {
+    if (event.type === 'job-removed') {
+      notifiedJobIds.delete(event.id);
+      return;
+    }
+    if (event.type === 'job-updated' && event.job.acknowledgedAt) {
+      notifiedJobIds.delete(event.job.id);
+      return;
+    }
     const notification = backgroundJobNotificationForEvent(event);
     if (!notification || notifiedJobIds.has(notification.jobId)) return;
-    notifiedJobIds.add(notification.jobId);
+    rememberNotifiedBackgroundJobId(notifiedJobIds, notification.jobId);
     if (deps.isAppFocused() || !deps.isNotificationSupported()) return;
     deps.showNotification(notification, deps.focusApp);
   };
+}
+
+function rememberNotifiedBackgroundJobId(ids: Set<string>, id: string): void {
+  ids.add(id);
+  if (ids.size <= MAX_NOTIFIED_BACKGROUND_JOB_IDS) return;
+  const oldestId = ids.values().next().value;
+  if (typeof oldestId === 'string') ids.delete(oldestId);
 }
 
 function applicationMenuTemplate(): MenuItemConstructorOptions[] {

--- a/apps/desktop/src/main/native-app.ts
+++ b/apps/desktop/src/main/native-app.ts
@@ -1,0 +1,225 @@
+import type { BackgroundJobEvent } from '@firebase-desk/repo-contracts/jobs';
+import {
+  app,
+  BrowserWindow,
+  type BrowserWindowConstructorOptions,
+  type ContextMenuParams,
+  Menu,
+  type MenuItemConstructorOptions,
+  nativeTheme,
+  Notification,
+  shell,
+} from 'electron';
+import {
+  MAIN_WINDOW_DEFAULT_HEIGHT,
+  MAIN_WINDOW_DEFAULT_WIDTH,
+  MAIN_WINDOW_MIN_HEIGHT,
+  MAIN_WINDOW_MIN_WIDTH,
+} from './main-window-constants.ts';
+import {
+  backgroundJobNotificationForEvent,
+  type NativeContextMenuAction,
+  nativeContextMenuActions,
+  shouldOpenExternally,
+} from './native-app-policy.ts';
+
+interface BackgroundJobNotifierDeps {
+  readonly focusApp: () => void;
+  readonly isAppFocused: () => boolean;
+  readonly isNotificationSupported: () => boolean;
+  readonly showNotification: (
+    notification: { readonly body: string; readonly title: string; },
+    onClick: () => void,
+  ) => void;
+}
+
+export function installNativeAppBehavior(): void {
+  nativeTheme.themeSource = 'system';
+  Menu.setApplicationMenu(Menu.buildFromTemplate(applicationMenuTemplate()));
+}
+
+export function mainWindowDefaults(): BrowserWindowConstructorOptions {
+  return {
+    height: MAIN_WINDOW_DEFAULT_HEIGHT,
+    minHeight: MAIN_WINDOW_MIN_HEIGHT,
+    minWidth: MAIN_WINDOW_MIN_WIDTH,
+    title: 'Firebase Desk',
+    ...(process.platform === 'darwin'
+      ? {
+        titleBarStyle: 'hiddenInset',
+        trafficLightPosition: { x: 12, y: 13 },
+      }
+      : {}),
+    width: MAIN_WINDOW_DEFAULT_WIDTH,
+  };
+}
+
+export function installNativeWindowBehavior(window: BrowserWindow): void {
+  window.webContents.setWindowOpenHandler(({ url }) => {
+    if (shouldOpenExternally(url, window.webContents.getURL())) {
+      void shell.openExternal(url);
+      return { action: 'deny' };
+    }
+    return { action: 'allow' };
+  });
+
+  window.webContents.on('will-navigate', (event, url) => {
+    if (!shouldOpenExternally(url, window.webContents.getURL())) return;
+    event.preventDefault();
+    void shell.openExternal(url);
+  });
+
+  window.webContents.on('context-menu', (_event, params) => {
+    const actions = nativeContextMenuActions(params, isDevelopmentRuntime());
+    if (actions.length === 0) return;
+    Menu.buildFromTemplate(contextMenuTemplate(actions, params, window)).popup({ window });
+  });
+}
+
+export function createBackgroundJobNotifier(
+  deps: BackgroundJobNotifierDeps = defaultBackgroundJobNotifierDeps(),
+): (event: BackgroundJobEvent) => void {
+  const notifiedJobIds = new Set<string>();
+  return (event) => {
+    const notification = backgroundJobNotificationForEvent(event);
+    if (!notification || notifiedJobIds.has(notification.jobId)) return;
+    notifiedJobIds.add(notification.jobId);
+    if (deps.isAppFocused() || !deps.isNotificationSupported()) return;
+    deps.showNotification(notification, deps.focusApp);
+  };
+}
+
+function applicationMenuTemplate(): MenuItemConstructorOptions[] {
+  const isMac = process.platform === 'darwin';
+  const isDev = isDevelopmentRuntime();
+  const template: MenuItemConstructorOptions[] = [
+    ...(isMac
+      ? [
+        {
+          label: app.name,
+          submenu: [
+            { role: 'about' },
+            { type: 'separator' },
+            { role: 'services' },
+            { type: 'separator' },
+            { role: 'hide' },
+            { role: 'hideOthers' },
+            { role: 'unhide' },
+            { type: 'separator' },
+            { role: 'quit' },
+          ],
+        } satisfies MenuItemConstructorOptions,
+      ]
+      : []),
+    {
+      label: 'File',
+      submenu: [
+        isMac ? { role: 'close' } : { role: 'quit' },
+      ],
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'pasteAndMatchStyle' },
+        { role: 'delete' },
+        { type: 'separator' },
+        { role: 'selectAll' },
+      ],
+    },
+    {
+      label: 'View',
+      submenu: [
+        ...(isDev
+          ? [
+            { role: 'reload' },
+            { role: 'forceReload' },
+            { role: 'toggleDevTools' },
+            { type: 'separator' },
+          ] satisfies MenuItemConstructorOptions[]
+          : []),
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+      ],
+    },
+    {
+      label: 'Window',
+      submenu: [
+        { role: 'minimize' },
+        ...(isMac ? [{ role: 'zoom' } satisfies MenuItemConstructorOptions] : []),
+        { role: 'close' },
+      ],
+    },
+  ];
+  return template;
+}
+
+function contextMenuTemplate(
+  actions: ReadonlyArray<NativeContextMenuAction>,
+  params: ContextMenuParams,
+  window: BrowserWindow,
+): MenuItemConstructorOptions[] {
+  return actions.map((action) => contextMenuItem(action, params, window));
+}
+
+function contextMenuItem(
+  action: NativeContextMenuAction,
+  params: ContextMenuParams,
+  window: BrowserWindow,
+): MenuItemConstructorOptions {
+  if (action === 'separator') return { type: 'separator' };
+  if (action === 'open-link') {
+    return {
+      click: () => {
+        if (params.linkURL) void shell.openExternal(params.linkURL);
+      },
+      label: 'Open Link in Browser',
+    };
+  }
+  if (action === 'inspect') {
+    return {
+      click: () => window.webContents.inspectElement(params.x, params.y),
+      label: 'Inspect Element',
+    };
+  }
+  if (action === 'paste-and-match-style') return { role: 'pasteAndMatchStyle' };
+  if (action === 'select-all') return { role: 'selectAll' };
+  return { role: action };
+}
+
+function defaultBackgroundJobNotifierDeps(): BackgroundJobNotifierDeps {
+  return {
+    focusApp,
+    isAppFocused: () => Boolean(BrowserWindow.getFocusedWindow()),
+    isNotificationSupported: () => Notification.isSupported(),
+    showNotification: ({ body, title }, onClick) => {
+      try {
+        const notification = new Notification({ body, title });
+        notification.on('click', onClick);
+        notification.show();
+      } catch {
+        // Native notification support varies by platform/session.
+      }
+    },
+  };
+}
+
+function focusApp(): void {
+  const window = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0];
+  if (!window) return;
+  if (window.isMinimized()) window.restore();
+  window.show();
+  window.focus();
+}
+
+function isDevelopmentRuntime(): boolean {
+  return !app.isPackaged || Boolean(process.env['ELECTRON_RENDERER_URL']);
+}

--- a/apps/desktop/src/main/native-app.ts
+++ b/apps/desktop/src/main/native-app.ts
@@ -18,6 +18,7 @@ import {
 } from './main-window-constants.ts';
 import {
   backgroundJobNotificationForEvent,
+  isInternalAppNavigation,
   type NativeContextMenuAction,
   nativeContextMenuActions,
   shouldOpenExternally,
@@ -59,16 +60,19 @@ export function mainWindowDefaults(): BrowserWindowConstructorOptions {
 export function installNativeWindowBehavior(window: BrowserWindow): void {
   window.webContents.setWindowOpenHandler(({ url }) => {
     if (shouldOpenExternally(url, window.webContents.getURL())) {
-      void shell.openExternal(url);
-      return { action: 'deny' };
+      openExternalSafely(url);
     }
-    return { action: 'allow' };
+    return { action: 'deny' };
   });
 
   window.webContents.on('will-navigate', (event, url) => {
-    if (!shouldOpenExternally(url, window.webContents.getURL())) return;
+    const currentUrl = window.webContents.getURL();
+    if (!shouldOpenExternally(url, currentUrl)) {
+      if (!isInternalAppNavigation(url, currentUrl)) event.preventDefault();
+      return;
+    }
     event.preventDefault();
-    void shell.openExternal(url);
+    openExternalSafely(url);
   });
 
   window.webContents.on('context-menu', (_event, params) => {
@@ -196,7 +200,7 @@ function contextMenuItem(
   if (action === 'open-link') {
     return {
       click: () => {
-        if (params.linkURL) void shell.openExternal(params.linkURL);
+        if (params.linkURL) openExternalSafely(params.linkURL);
       },
       label: 'Open Link in Browser',
     };
@@ -235,6 +239,10 @@ function focusApp(): void {
   if (window.isMinimized()) window.restore();
   window.show();
   window.focus();
+}
+
+function openExternalSafely(url: string): void {
+  void shell.openExternal(url).catch(() => undefined);
 }
 
 function isDevelopmentRuntime(): boolean {

--- a/apps/desktop/src/main/window-state-store.test.ts
+++ b/apps/desktop/src/main/window-state-store.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  loadMainWindowState,
+  saveMainWindowState,
+  windowOptionsFromState,
+} from './window-state-store.ts';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
+});
+
+describe('window state store', () => {
+  it('saves and restores usable main window bounds', async () => {
+    const userDataPath = await makeTempDir();
+
+    await saveMainWindowState(userDataPath, {
+      bounds: { height: 100, width: 200, x: 44, y: 55 },
+      maximized: true,
+    });
+
+    await expect(loadMainWindowState(userDataPath)).resolves.toEqual({
+      bounds: { height: 640, width: 960, x: 44, y: 55 },
+      maximized: true,
+    });
+  });
+
+  it('ignores invalid persisted window state', async () => {
+    const userDataPath = await makeTempDir();
+    await writeFile(join(userDataPath, 'window-state.json'), JSON.stringify({ bad: true }));
+
+    await expect(loadMainWindowState(userDataPath)).resolves.toBe(null);
+  });
+
+  it('maps restored state to BrowserWindow options', () => {
+    expect(windowOptionsFromState({
+      bounds: { height: 700, width: 1000, x: 10, y: 20 },
+      maximized: false,
+    }, [{ height: 900, width: 1440, x: 0, y: 0 }])).toEqual({
+      height: 700,
+      width: 1000,
+      x: 10,
+      y: 20,
+    });
+  });
+
+  it('drops off-screen coordinates when restoring window options', () => {
+    expect(windowOptionsFromState({
+      bounds: { height: 700, width: 1000, x: 5000, y: 5000 },
+      maximized: false,
+    }, [{ height: 900, width: 1440, x: 0, y: 0 }])).toEqual({
+      height: 700,
+      width: 1000,
+    });
+  });
+});
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'firebase-desk-window-state-'));
+  tempDirs.push(dir);
+  return dir;
+}

--- a/apps/desktop/src/main/window-state-store.test.ts
+++ b/apps/desktop/src/main/window-state-store.test.ts
@@ -1,10 +1,13 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import type { BrowserWindow } from 'electron';
+import { EventEmitter } from 'node:events';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   loadMainWindowState,
   saveMainWindowState,
+  trackMainWindowState,
   windowOptionsFromState,
 } from './window-state-store.ts';
 
@@ -36,6 +39,25 @@ describe('window state store', () => {
     await expect(loadMainWindowState(userDataPath)).resolves.toBe(null);
   });
 
+  it('throws unexpected persisted window state read errors', async () => {
+    const userDataPath = await makeTempDir();
+    await mkdir(join(userDataPath, 'window-state.json'));
+
+    await expect(loadMainWindowState(userDataPath)).rejects.toMatchObject({ code: 'EISDIR' });
+  });
+
+  it('handles tracked save failures', async () => {
+    const userDataPath = await makeTempDir();
+    const blockedUserDataPath = join(userDataPath, 'blocked');
+    await writeFile(blockedUserDataPath, 'not a directory');
+    const window = new FakeBrowserWindow();
+
+    trackMainWindowState(window as unknown as BrowserWindow, blockedUserDataPath);
+    window.emit('close');
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  });
+
   it('maps restored state to BrowserWindow options', () => {
     expect(windowOptionsFromState({
       bounds: { height: 700, width: 1000, x: 10, y: 20 },
@@ -63,4 +85,18 @@ async function makeTempDir(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'firebase-desk-window-state-'));
   tempDirs.push(dir);
   return dir;
+}
+
+class FakeBrowserWindow extends EventEmitter {
+  getBounds() {
+    return { height: 700, width: 1000, x: 10, y: 20 };
+  }
+
+  getNormalBounds() {
+    return this.getBounds();
+  }
+
+  isMaximized() {
+    return false;
+  }
 }

--- a/apps/desktop/src/main/window-state-store.ts
+++ b/apps/desktop/src/main/window-state-store.ts
@@ -1,0 +1,117 @@
+import type { BrowserWindow, BrowserWindowConstructorOptions, Rectangle } from 'electron';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { z } from 'zod';
+import { MAIN_WINDOW_MIN_HEIGHT, MAIN_WINDOW_MIN_WIDTH } from './main-window-constants.ts';
+import { writeJsonAtomic } from './storage/atomic-write.ts';
+
+export interface MainWindowState {
+  readonly bounds: Rectangle;
+  readonly maximized: boolean;
+}
+
+export interface DisplayArea {
+  readonly height: number;
+  readonly width: number;
+  readonly x: number;
+  readonly y: number;
+}
+
+const WindowStateFileSchema = z.object({
+  state: z.object({
+    bounds: z.object({
+      height: z.number().int().positive(),
+      width: z.number().int().positive(),
+      x: z.number().int(),
+      y: z.number().int(),
+    }),
+    maximized: z.boolean(),
+  }),
+  version: z.literal(1),
+});
+
+export async function loadMainWindowState(userDataPath: string): Promise<MainWindowState | null> {
+  try {
+    const raw = await readFile(windowStatePath(userDataPath), 'utf8');
+    const parsed = WindowStateFileSchema.safeParse(JSON.parse(raw) as unknown);
+    if (!parsed.success) return null;
+    return normalizeWindowState(parsed.data.state);
+  } catch {
+    return null;
+  }
+}
+
+export async function saveMainWindowState(
+  userDataPath: string,
+  state: MainWindowState,
+): Promise<void> {
+  await writeJsonAtomic(windowStatePath(userDataPath), {
+    state: normalizeWindowState(state),
+    version: 1,
+  });
+}
+
+export function windowOptionsFromState(
+  state: MainWindowState | null,
+  displayAreas: ReadonlyArray<DisplayArea> = [],
+): BrowserWindowConstructorOptions {
+  if (!state) return {};
+  const { bounds } = normalizeWindowState(state);
+  if (displayAreas.length > 0 && !overlapsAnyDisplay(bounds, displayAreas)) {
+    return { height: bounds.height, width: bounds.width };
+  }
+  return bounds;
+}
+
+export function trackMainWindowState(window: BrowserWindow, userDataPath: string): void {
+  let saveTimer: ReturnType<typeof setTimeout> | null = null;
+  const scheduleSave = () => {
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = setTimeout(() => {
+      saveTimer = null;
+      void saveMainWindowState(userDataPath, snapshotWindowState(window));
+    }, 250);
+  };
+  const saveNow = () => {
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = null;
+    void saveMainWindowState(userDataPath, snapshotWindowState(window));
+  };
+  window.on('move', scheduleSave);
+  window.on('resize', scheduleSave);
+  window.on('maximize', scheduleSave);
+  window.on('unmaximize', scheduleSave);
+  window.on('close', saveNow);
+}
+
+function snapshotWindowState(window: BrowserWindow): MainWindowState {
+  const maximized = window.isMaximized();
+  return {
+    bounds: maximized ? window.getNormalBounds() : window.getBounds(),
+    maximized,
+  };
+}
+
+function normalizeWindowState(state: MainWindowState): MainWindowState {
+  return {
+    bounds: {
+      ...state.bounds,
+      height: Math.max(MAIN_WINDOW_MIN_HEIGHT, state.bounds.height),
+      width: Math.max(MAIN_WINDOW_MIN_WIDTH, state.bounds.width),
+    },
+    maximized: state.maximized,
+  };
+}
+
+function overlapsAnyDisplay(bounds: Rectangle, displayAreas: ReadonlyArray<DisplayArea>): boolean {
+  return displayAreas.some((display) =>
+    bounds.x < display.x + display.width
+    && bounds.x + bounds.width > display.x
+    && bounds.y < display.y + display.height
+    && bounds.y + bounds.height > display.y
+  );
+}
+
+function windowStatePath(userDataPath: string): string {
+  return join(userDataPath, 'window-state.json');
+}

--- a/apps/desktop/src/main/window-state-store.ts
+++ b/apps/desktop/src/main/window-state-store.ts
@@ -31,14 +31,27 @@ const WindowStateFileSchema = z.object({
 });
 
 export async function loadMainWindowState(userDataPath: string): Promise<MainWindowState | null> {
+  let raw: string;
   try {
-    const raw = await readFile(windowStatePath(userDataPath), 'utf8');
-    const parsed = WindowStateFileSchema.safeParse(JSON.parse(raw) as unknown);
-    if (!parsed.success) return null;
-    return normalizeWindowState(parsed.data.state);
-  } catch {
+    raw = await readFile(windowStatePath(userDataPath), 'utf8');
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) return null;
+    throw error;
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(raw) as unknown;
+  } catch (error) {
+    if (error instanceof SyntaxError) return null;
+    throw error;
+  }
+
+  const parsed = WindowStateFileSchema.safeParse(value);
+  if (!parsed.success) {
     return null;
   }
+  return normalizeWindowState(parsed.data.state);
 }
 
 export async function saveMainWindowState(
@@ -69,13 +82,13 @@ export function trackMainWindowState(window: BrowserWindow, userDataPath: string
     if (saveTimer) clearTimeout(saveTimer);
     saveTimer = setTimeout(() => {
       saveTimer = null;
-      void saveMainWindowState(userDataPath, snapshotWindowState(window));
+      saveMainWindowStateSafely(userDataPath, snapshotWindowState(window));
     }, 250);
   };
   const saveNow = () => {
     if (saveTimer) clearTimeout(saveTimer);
     saveTimer = null;
-    void saveMainWindowState(userDataPath, snapshotWindowState(window));
+    saveMainWindowStateSafely(userDataPath, snapshotWindowState(window));
   };
   window.on('move', scheduleSave);
   window.on('resize', scheduleSave);
@@ -90,6 +103,10 @@ function snapshotWindowState(window: BrowserWindow): MainWindowState {
     bounds: maximized ? window.getNormalBounds() : window.getBounds(),
     maximized,
   };
+}
+
+function saveMainWindowStateSafely(userDataPath: string, state: MainWindowState): void {
+  void saveMainWindowState(userDataPath, state).catch(() => undefined);
 }
 
 function normalizeWindowState(state: MainWindowState): MainWindowState {
@@ -114,4 +131,10 @@ function overlapsAnyDisplay(bounds: Rectangle, displayAreas: ReadonlyArray<Displ
 
 function windowStatePath(userDataPath: string): string {
   return join(userDataPath, 'window-state.json');
+}
+
+function isNodeErrorCode(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return error instanceof Error
+    && 'code' in error
+    && (error as NodeJS.ErrnoException).code === code;
 }

--- a/apps/desktop/src/preload/index.test.ts
+++ b/apps/desktop/src/preload/index.test.ts
@@ -1,5 +1,5 @@
 import { JOB_EVENT_CHANNEL, SCRIPT_RUN_EVENT_CHANNEL } from '@firebase-desk/ipc-schemas';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DesktopApi } from './index.ts';
 
 const electronMocks = vi.hoisted(() => ({
@@ -25,6 +25,20 @@ describe('preload script runner api', () => {
     vi.resetModules();
     vi.clearAllMocks();
     await import('./index.ts');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('exposes the desktop api when document is unavailable', async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.stubGlobal('document', undefined);
+
+    await import('./index.ts');
+
+    expect(exposedApi().app.getConfig).toEqual(expect.any(Function));
   });
 
   it('subscribes and unsubscribes to script runner events', () => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -113,4 +113,8 @@ const api = {
 
 export type DesktopApi = typeof api;
 
+window.addEventListener('DOMContentLoaded', () => {
+  document.documentElement.dataset.platform = process.platform;
+});
+
 contextBridge.exposeInMainWorld('firebaseDesk', api);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -113,8 +113,13 @@ const api = {
 
 export type DesktopApi = typeof api;
 
-window.addEventListener('DOMContentLoaded', () => {
+function setPlatformDataset(): void {
   document.documentElement.dataset.platform = process.platform;
-});
+}
+
+setPlatformDataset();
+if (document.readyState === 'loading') {
+  window.addEventListener('DOMContentLoaded', setPlatformDataset, { once: true });
+}
 
 contextBridge.exposeInMainWorld('firebaseDesk', api);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -113,13 +113,19 @@ const api = {
 
 export type DesktopApi = typeof api;
 
-function setPlatformDataset(): void {
-  document.documentElement.dataset.platform = process.platform;
-}
-
-setPlatformDataset();
-if (document.readyState === 'loading') {
-  window.addEventListener('DOMContentLoaded', setPlatformDataset, { once: true });
-}
-
 contextBridge.exposeInMainWorld('firebaseDesk', api);
+installPlatformDataset();
+
+function installPlatformDataset(): void {
+  setPlatformDataset();
+  if (globalThis.document?.readyState === 'loading') {
+    globalThis.window?.addEventListener('DOMContentLoaded', setPlatformDataset, { once: true });
+  }
+}
+
+function setPlatformDataset(): void {
+  const platform = globalThis.process?.platform;
+  const root = globalThis.document?.documentElement;
+  if (typeof platform !== 'string' || !root) return;
+  root.dataset.platform = platform;
+}

--- a/apps/desktop/src/renderer/app/AppHeader.test.tsx
+++ b/apps/desktop/src/renderer/app/AppHeader.test.tsx
@@ -1,0 +1,44 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AppHeader } from './AppHeader.tsx';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('AppHeader', () => {
+  it('reserves macOS traffic light space from the renderer platform', () => {
+    stubNavigator('MacIntel', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)');
+
+    const { container } = render(<AppHeader {...props()} />);
+
+    expect(container.querySelector('.native-titlebar-traffic-spacer')).toBeTruthy();
+  });
+
+  it('does not reserve traffic light space on other platforms', () => {
+    stubNavigator('Win32', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+
+    const { container } = render(<AppHeader {...props()} />);
+
+    expect(container.querySelector('.native-titlebar-traffic-spacer')).toBeNull();
+  });
+});
+
+function stubNavigator(platform: string, userAgent: string): void {
+  vi.stubGlobal('navigator', { platform, userAgent });
+}
+
+function props(): Parameters<typeof AppHeader>[0] {
+  return {
+    canGoBack: false,
+    canGoForward: false,
+    dataMode: 'mock',
+    mode: 'system',
+    onAddProject: vi.fn(),
+    onBack: vi.fn(),
+    onForward: vi.fn(),
+    onModeChange: vi.fn(),
+    onOpenSettings: vi.fn(),
+    resolvedTheme: 'light',
+  };
+}

--- a/apps/desktop/src/renderer/app/AppHeader.test.tsx
+++ b/apps/desktop/src/renderer/app/AppHeader.test.tsx
@@ -3,12 +3,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AppHeader } from './AppHeader.tsx';
 
 afterEach(() => {
+  delete document.documentElement.dataset.platform;
   vi.unstubAllGlobals();
 });
 
 describe('AppHeader', () => {
-  it('reserves macOS traffic light space from the renderer platform', () => {
-    stubNavigator('MacIntel', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)');
+  it('reserves macOS traffic light space from the preload platform', () => {
+    document.documentElement.dataset.platform = 'darwin';
+    stubNavigator('Win32', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
 
     const { container } = render(<AppHeader {...props()} />);
 
@@ -16,7 +18,8 @@ describe('AppHeader', () => {
   });
 
   it('does not reserve traffic light space on other platforms', () => {
-    stubNavigator('Win32', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+    document.documentElement.dataset.platform = 'win32';
+    stubNavigator('MacIntel', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)');
 
     const { container } = render(<AppHeader {...props()} />);
 

--- a/apps/desktop/src/renderer/app/AppHeader.tsx
+++ b/apps/desktop/src/renderer/app/AppHeader.tsx
@@ -32,6 +32,7 @@ export function AppHeader(
 ) {
   return (
     <header className='app-region-drag native-titlebar flex min-w-0 items-center gap-2 border-b border-border-subtle bg-bg-panel px-2'>
+      <span className='native-titlebar-traffic-spacer shrink-0' aria-hidden='true' />
       <div className='app-region-no-drag flex h-full shrink-0 items-center gap-1 border-r border-border-subtle pr-2'>
         <IconButton
           disabled={!canGoBack}

--- a/apps/desktop/src/renderer/app/AppHeader.tsx
+++ b/apps/desktop/src/renderer/app/AppHeader.tsx
@@ -31,8 +31,8 @@ export function AppHeader(
   }: AppHeaderProps,
 ) {
   return (
-    <header className='flex min-w-0 items-center gap-2 border-b border-border-subtle bg-bg-panel px-2'>
-      <div className='flex h-full shrink-0 items-center gap-1 border-r border-border-subtle pr-2'>
+    <header className='app-region-drag native-titlebar flex min-w-0 items-center gap-2 border-b border-border-subtle bg-bg-panel px-2'>
+      <div className='app-region-no-drag flex h-full shrink-0 items-center gap-1 border-r border-border-subtle pr-2'>
         <IconButton
           disabled={!canGoBack}
           icon={<ArrowLeft size={14} aria-hidden='true' />}
@@ -57,7 +57,7 @@ export function AppHeader(
         <strong className='truncate text-sm font-semibold text-text-primary'>Firebase Desk</strong>
         <Badge variant={dataMode === 'live' ? 'warning' : 'neutral'}>{dataMode}</Badge>
       </div>
-      <div className='ml-auto flex shrink-0 items-center gap-2'>
+      <div className='app-region-no-drag ml-auto flex shrink-0 items-center gap-2'>
         <Button variant='secondary' onClick={onOpenSettings}>
           <Settings size={14} aria-hidden='true' /> Settings
         </Button>

--- a/apps/desktop/src/renderer/app/AppHeader.tsx
+++ b/apps/desktop/src/renderer/app/AppHeader.tsx
@@ -30,9 +30,12 @@ export function AppHeader(
     resolvedTheme,
   }: AppHeaderProps,
 ) {
+  const reserveTrafficLightSpace = isMacPlatform();
   return (
     <header className='app-region-drag native-titlebar flex min-w-0 items-center gap-2 border-b border-border-subtle bg-bg-panel px-2'>
-      <span className='native-titlebar-traffic-spacer shrink-0' aria-hidden='true' />
+      {reserveTrafficLightSpace
+        ? <span className='native-titlebar-traffic-spacer shrink-0' aria-hidden='true' />
+        : null}
       <div className='app-region-no-drag flex h-full shrink-0 items-center gap-1 border-r border-border-subtle pr-2'>
         <IconButton
           disabled={!canGoBack}
@@ -69,6 +72,11 @@ export function AppHeader(
       </div>
     </header>
   );
+}
+
+function isMacPlatform(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return /\bMac/.test(navigator.platform) || /\bMac OS X\b/.test(navigator.userAgent);
 }
 
 function ThemeSegment(

--- a/apps/desktop/src/renderer/app/AppHeader.tsx
+++ b/apps/desktop/src/renderer/app/AppHeader.tsx
@@ -75,6 +75,10 @@ export function AppHeader(
 }
 
 function isMacPlatform(): boolean {
+  const preloadPlatform = typeof document === 'undefined'
+    ? undefined
+    : document.documentElement.dataset.platform;
+  if (preloadPlatform) return preloadPlatform === 'darwin';
   if (typeof navigator === 'undefined') return false;
   return /\bMac/.test(navigator.platform) || /\bMac OS X\b/.test(navigator.userAgent);
 }

--- a/apps/desktop/src/renderer/app/RepositoryProvider.test.tsx
+++ b/apps/desktop/src/renderer/app/RepositoryProvider.test.tsx
@@ -28,10 +28,7 @@ describe('createRepositories', () => {
   it('uses desktop settings in mock data mode when the desktop API is available', async () => {
     const save = vi.fn(async () => ({ ...snapshot, dataMode: 'live' as const }));
     const onDataModeChange = vi.fn();
-    vi.stubGlobal('firebaseDesk', {
-      projects: {
-        list: vi.fn(async () => []),
-      },
+    stubDesktopApi({
       settings: {
         load: vi.fn(async () => snapshot),
         save,
@@ -50,7 +47,7 @@ describe('createRepositories', () => {
   it('uses desktop activity in mock data mode when the desktop API is available', async () => {
     const listActivity = vi.fn(async () => []);
     const listJobs = vi.fn(async () => []);
-    vi.stubGlobal('firebaseDesk', {
+    stubDesktopApi({
       activity: {
         append: vi.fn(),
         clear: vi.fn(),
@@ -58,6 +55,7 @@ describe('createRepositories', () => {
         list: listActivity,
       },
       jobs: {
+        acknowledgeIssues: vi.fn(),
         cancel: vi.fn(),
         clearCompleted: vi.fn(),
         list: listJobs,
@@ -65,15 +63,6 @@ describe('createRepositories', () => {
         pickImportFile: vi.fn(),
         start: vi.fn(),
         subscribe: vi.fn(() => () => {}),
-      },
-      projects: {
-        list: vi.fn(async () => []),
-      },
-      settings: {
-        load: vi.fn(async () => snapshot),
-        save: vi.fn(async () => snapshot),
-        getHotkeyOverrides: vi.fn(async () => ({})),
-        setHotkeyOverrides: vi.fn(async () => {}),
       },
     });
 
@@ -93,24 +82,14 @@ describe('createRepositories', () => {
       errors: [],
       durationMs: 1,
     }));
-    vi.stubGlobal('firebaseDesk', {
+    stubDesktopApi({
       auth: {
+        ...desktopAuthApi(),
         listUsers,
       },
       firestore: {
+        ...desktopFirestoreApi(),
         listRootCollections: vi.fn(async () => []),
-      },
-      jobs: {
-        cancel: vi.fn(),
-        clearCompleted: vi.fn(),
-        list: vi.fn(async () => []),
-        pickExportFile: vi.fn(),
-        pickImportFile: vi.fn(),
-        start: vi.fn(),
-        subscribe: vi.fn(() => () => {}),
-      },
-      projects: {
-        list: vi.fn(async () => []),
       },
       scriptRunner: {
         run: runScript,
@@ -144,4 +123,124 @@ describe('createRepositories', () => {
       source: 'return 1;',
     });
   });
+
+  it('rejects live data mode when the desktop live API is unavailable', async () => {
+    const save = vi.fn(async () => ({ ...snapshot, dataMode: 'live' as const }));
+    const onDataModeChange = vi.fn();
+    vi.stubGlobal('firebaseDesk', {
+      settings: {
+        load: vi.fn(async () => snapshot),
+        save,
+        getHotkeyOverrides: vi.fn(async () => ({})),
+        setHotkeyOverrides: vi.fn(async () => {}),
+      },
+    });
+
+    const repositories = createRepositories({ dataMode: 'mock', onDataModeChange });
+
+    await expect(repositories.settings.save({ dataMode: 'live' })).rejects.toThrow(
+      'Live mode requires the Firebase Desk desktop app.',
+    );
+    expect(save).not.toHaveBeenCalled();
+    expect(onDataModeChange).not.toHaveBeenCalled();
+  });
 });
+
+function stubDesktopApi(overrides: Partial<DesktopApi>): void {
+  vi.stubGlobal('firebaseDesk', {
+    activity: desktopActivityApi(),
+    auth: desktopAuthApi(),
+    firestore: desktopFirestoreApi(),
+    jobs: desktopJobsApi(),
+    projects: desktopProjectsApi(),
+    scriptRunner: desktopScriptRunnerApi(),
+    settings: desktopSettingsApi(),
+    ...overrides,
+  });
+}
+
+function desktopActivityApi(): DesktopActivityApi {
+  return {
+    append: vi.fn(),
+    clear: vi.fn(),
+    export: vi.fn(),
+    list: vi.fn(async () => []),
+  };
+}
+
+function desktopAuthApi(): DesktopAuthApi {
+  return {
+    getUser: vi.fn(async () => null),
+    listUsers: vi.fn(async () => ({ items: [], nextCursor: null })),
+    searchUsers: vi.fn(async () => []),
+    setCustomClaims: vi.fn(async () => authUser()),
+  };
+}
+
+function desktopFirestoreApi(): DesktopFirestoreApi {
+  return {
+    createDocument: vi.fn(),
+    deleteDocument: vi.fn(),
+    generateDocumentId: vi.fn(),
+    getDocument: vi.fn(),
+    listDocuments: vi.fn(),
+    listRootCollections: vi.fn(async () => []),
+    listSubcollections: vi.fn(),
+    runQuery: vi.fn(),
+    saveDocument: vi.fn(),
+    updateDocumentFields: vi.fn(),
+  };
+}
+
+function desktopJobsApi(): DesktopJobsApi {
+  return {
+    acknowledgeIssues: vi.fn(),
+    cancel: vi.fn(),
+    clearCompleted: vi.fn(),
+    list: vi.fn(async () => []),
+    pickExportFile: vi.fn(),
+    pickImportFile: vi.fn(),
+    start: vi.fn(),
+    subscribe: vi.fn(() => () => {}),
+  };
+}
+
+function desktopProjectsApi(): DesktopProjectsApi {
+  return {
+    add: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn(async () => []),
+    pickServiceAccountFile: vi.fn(),
+    remove: vi.fn(),
+    update: vi.fn(),
+    validateServiceAccount: vi.fn(),
+  };
+}
+
+function desktopScriptRunnerApi(): DesktopScriptRunnerApi {
+  return {
+    cancel: vi.fn(async () => {}),
+    run: vi.fn(async () => ({ returnValue: null, logs: [], errors: [], durationMs: 1 })),
+    subscribe: vi.fn(() => () => {}),
+  };
+}
+
+function desktopSettingsApi(): DesktopSettingsApi {
+  return {
+    load: vi.fn(async () => snapshot),
+    save: vi.fn(async () => snapshot),
+    getHotkeyOverrides: vi.fn(async () => ({})),
+    setHotkeyOverrides: vi.fn(async () => {}),
+  };
+}
+
+function authUser(): Awaited<ReturnType<DesktopAuthApi['setCustomClaims']>> {
+  return {
+    customClaims: {},
+    disabled: false,
+    displayName: null,
+    email: null,
+    provider: 'password',
+    uid: 'user-1',
+  };
+}

--- a/apps/desktop/src/renderer/app/RepositoryProvider.tsx
+++ b/apps/desktop/src/renderer/app/RepositoryProvider.tsx
@@ -51,6 +51,45 @@ export interface CreateRepositoriesOptions {
   readonly onDataModeChange?: (dataMode: DataMode) => void;
 }
 
+const LIVE_MODE_UNAVAILABLE_MESSAGE =
+  'Live mode requires the Firebase Desk desktop app. Open the desktop app to use live Firebase data.';
+
+const ACTIVITY_API_METHODS = ['append', 'clear', 'export', 'list'] as const;
+const AUTH_API_METHODS = ['getUser', 'listUsers', 'searchUsers', 'setCustomClaims'] as const;
+const FIRESTORE_API_METHODS = [
+  'createDocument',
+  'deleteDocument',
+  'generateDocumentId',
+  'getDocument',
+  'listDocuments',
+  'listRootCollections',
+  'listSubcollections',
+  'runQuery',
+  'saveDocument',
+  'updateDocumentFields',
+] as const;
+const JOBS_API_METHODS = [
+  'acknowledgeIssues',
+  'cancel',
+  'clearCompleted',
+  'list',
+  'pickExportFile',
+  'pickImportFile',
+  'start',
+  'subscribe',
+] as const;
+const PROJECTS_API_METHODS = [
+  'add',
+  'get',
+  'list',
+  'pickServiceAccountFile',
+  'remove',
+  'update',
+  'validateServiceAccount',
+] as const;
+const SCRIPT_RUNNER_API_METHODS = ['cancel', 'run', 'subscribe'] as const;
+const SETTINGS_API_METHODS = ['getHotkeyOverrides', 'load', 'save', 'setHotkeyOverrides'] as const;
+
 export function createMockRepositories(): RepositorySet {
   return {
     activity: new MockActivityLogRepository(),
@@ -66,12 +105,15 @@ export function createMockRepositories(): RepositorySet {
 export function createRepositories(
   { dataMode, onDataModeChange }: CreateRepositoriesOptions,
 ): RepositorySet {
-  const desktopApiAvailable = hasDesktopApi();
-  const settings = desktopApiAvailable ? new IpcSettingsRepository() : new MockSettingsRepository();
-  const activity = desktopApiAvailable
+  const liveApiAvailable = hasLiveDesktopApi();
+  const settings = new LiveModeGuardSettingsRepository(
+    hasDesktopSettingsApi() ? new IpcSettingsRepository() : new MockSettingsRepository(),
+    () => liveApiAvailable,
+  );
+  const activity = hasDesktopActivityApi()
     ? new IpcActivityLogRepository()
     : new MockActivityLogRepository();
-  const jobs = desktopApiAvailable
+  const jobs = hasDesktopJobsApi()
     ? new IpcBackgroundJobRepository()
     : new MockBackgroundJobRepository();
   const repositories: RepositorySet = dataMode === 'live'
@@ -133,6 +175,63 @@ class DataModeNotifyingSettingsRepository implements SettingsRepository {
   }
 }
 
-function hasDesktopApi(): boolean {
-  return typeof window !== 'undefined' && Boolean(window.firebaseDesk?.projects?.list);
+class LiveModeGuardSettingsRepository implements SettingsRepository {
+  constructor(
+    private readonly delegate: SettingsRepository,
+    private readonly liveApiAvailable: () => boolean,
+  ) {}
+
+  async load(): Promise<SettingsSnapshot> {
+    return await this.delegate.load();
+  }
+
+  async save(patch: SettingsPatch): Promise<SettingsSnapshot> {
+    if (patch.dataMode === 'live' && !this.liveApiAvailable()) {
+      throw new Error(LIVE_MODE_UNAVAILABLE_MESSAGE);
+    }
+    return await this.delegate.save(patch);
+  }
+
+  async getHotkeyOverrides(): Promise<HotkeyOverrides> {
+    return await this.delegate.getHotkeyOverrides();
+  }
+
+  async setHotkeyOverrides(overrides: HotkeyOverrides): Promise<void> {
+    await this.delegate.setHotkeyOverrides(overrides);
+  }
+}
+
+function hasDesktopActivityApi(): boolean {
+  return hasMethods(desktopApi()?.activity, ACTIVITY_API_METHODS);
+}
+
+function hasDesktopJobsApi(): boolean {
+  return hasMethods(desktopApi()?.jobs, JOBS_API_METHODS);
+}
+
+function hasDesktopSettingsApi(): boolean {
+  return hasMethods(desktopApi()?.settings, SETTINGS_API_METHODS);
+}
+
+function hasLiveDesktopApi(): boolean {
+  const api = desktopApi();
+  return hasDesktopSettingsApi()
+    && hasMethods(api?.auth, AUTH_API_METHODS)
+    && hasMethods(api?.firestore, FIRESTORE_API_METHODS)
+    && hasMethods(api?.projects, PROJECTS_API_METHODS)
+    && hasMethods(api?.scriptRunner, SCRIPT_RUNNER_API_METHODS);
+}
+
+function desktopApi(): Partial<DesktopApi> | undefined {
+  if (typeof window === 'undefined') return undefined;
+  return (window as Window & { readonly firebaseDesk?: Partial<DesktopApi>; }).firebaseDesk;
+}
+
+function hasMethods<TMethod extends string>(
+  value: unknown,
+  methods: ReadonlyArray<TMethod>,
+): value is Record<TMethod, (...args: never[]) => unknown> {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return methods.every((method) => typeof record[method] === 'function');
 }

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -21,6 +21,18 @@
     user-select: none;
   }
 
+  :where(.app-region-drag) {
+    -webkit-app-region: drag;
+  }
+
+  :where(.app-region-no-drag, button, a, [role='button'], [role='tab'], [role='menuitem'], input, select, textarea, [contenteditable='true']) {
+    -webkit-app-region: no-drag;
+  }
+
+  :root[data-platform='darwin'] :where(.native-titlebar) {
+    padding-left: 5rem;
+  }
+
   :where(input, textarea, [contenteditable='true'], .select-text, .select-text *, .monaco-editor, .monaco-editor *) {
     user-select: text;
   }

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -29,8 +29,17 @@
     -webkit-app-region: no-drag;
   }
 
+  :where(.native-titlebar-traffic-spacer) {
+    display: none;
+  }
+
   :root[data-platform='darwin'] :where(.native-titlebar) {
-    padding-left: 5rem;
+    padding-left: 0.5rem;
+  }
+
+  :root[data-platform='darwin'] :where(.native-titlebar-traffic-spacer) {
+    display: block;
+    width: 6.25rem;
   }
 
   :where(input, textarea, [contenteditable='true'], .select-text, .select-text *, .monaco-editor, .monaco-editor *) {

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -30,14 +30,6 @@
   }
 
   :where(.native-titlebar-traffic-spacer) {
-    display: none;
-  }
-
-  :root[data-platform='darwin'] :where(.native-titlebar) {
-    padding-left: 0.5rem;
-  }
-
-  :root[data-platform='darwin'] :where(.native-titlebar-traffic-spacer) {
     display: block;
     width: 6.25rem;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-desk",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "description": "Firebase Desk monorepo root.",
   "license": "MIT",

--- a/packages/repo-contracts/src/firestore.test.ts
+++ b/packages/repo-contracts/src/firestore.test.ts
@@ -8,6 +8,13 @@ import {
   isFirestoreDocumentPath,
 } from './firestore.ts';
 
+const DOCUMENT_OVERHEAD_BYTES = 32;
+const VALUE_FIELD_NAME_BYTES = 6;
+
+function estimateSingleFieldDocumentBytes(value: unknown): number {
+  return estimateFirestoreDocumentBytes({ value });
+}
+
 describe('Firestore path helpers', () => {
   it('classifies collection and document paths without filtering empty segments', () => {
     expect(isFirestoreCollectionPath('orders')).toBe(true);
@@ -31,20 +38,92 @@ describe('Firestore path helpers', () => {
 });
 
 describe('Firestore document size estimates', () => {
-  it('estimates nested document bytes without runtime-specific APIs', () => {
-    expect(estimateFirestoreDocumentBytes({
-      active: true,
-      name: 'Ada',
-      tags: ['x', 'λ'],
-    })).toBe(191);
+  it('counts string field values as UTF-8 bytes plus one byte', () => {
+    expect(estimateSingleFieldDocumentBytes('tasks')).toBe(
+      DOCUMENT_OVERHEAD_BYTES + VALUE_FIELD_NAME_BYTES + 6,
+    );
+    expect(estimateSingleFieldDocumentBytes('λ')).toBe(
+      DOCUMENT_OVERHEAD_BYTES + VALUE_FIELD_NAME_BYTES + 3,
+    );
+    expect(estimateSingleFieldDocumentBytes('🔥')).toBe(
+      DOCUMENT_OVERHEAD_BYTES + VALUE_FIELD_NAME_BYTES + 5,
+    );
   });
 
-  it('accounts for multibyte strings and nested object keys', () => {
-    expect(estimateFirestoreDocumentBytes({
-      meta: {
-        emoji: '🔥',
-        score: 12,
+  it('adds document name size when a path is provided', () => {
+    expect(estimateFirestoreDocumentBytes(
+      {},
+      { documentPath: 'users/jeff/tasks/my_task_id' },
+    )).toBe(DOCUMENT_OVERHEAD_BYTES + 44);
+  });
+
+  it('uses documented scalar value sizes', () => {
+    const base = DOCUMENT_OVERHEAD_BYTES + VALUE_FIELD_NAME_BYTES;
+    expect(estimateSingleFieldDocumentBytes(null)).toBe(base + 1);
+    expect(estimateSingleFieldDocumentBytes(true)).toBe(base + 1);
+    expect(estimateSingleFieldDocumentBytes(false)).toBe(base + 1);
+    expect(estimateSingleFieldDocumentBytes(7)).toBe(base + 8);
+    expect(estimateSingleFieldDocumentBytes(7.5)).toBe(base + 8);
+    expect(estimateSingleFieldDocumentBytes('Personal')).toBe(base + 9);
+  });
+
+  it('omits undefined fields because Firestore has no undefined value type', () => {
+    expect(estimateSingleFieldDocumentBytes(undefined)).toBe(DOCUMENT_OVERHEAD_BYTES);
+    expect(estimateFirestoreDocumentBytes({ kept: false, omitted: undefined })).toBe(
+      DOCUMENT_OVERHEAD_BYTES + 5 + 1,
+    );
+  });
+
+  it('uses documented timestamp and date-time value sizes', () => {
+    const base = DOCUMENT_OVERHEAD_BYTES + VALUE_FIELD_NAME_BYTES;
+    expect(estimateSingleFieldDocumentBytes({
+      __type__: 'timestamp',
+      value: '2026-01-01T00:00:00Z',
+    })).toBe(base + 8);
+    expect(estimateSingleFieldDocumentBytes(new Date('2026-01-01T00:00:00Z'))).toBe(base + 8);
+  });
+
+  it('uses documented geo point, reference, bytes, and vector value sizes', () => {
+    const base = DOCUMENT_OVERHEAD_BYTES + VALUE_FIELD_NAME_BYTES;
+    expect(estimateSingleFieldDocumentBytes({ __type__: 'geoPoint', latitude: 1, longitude: 2 }))
+      .toBe(base + 16);
+    expect(estimateSingleFieldDocumentBytes({
+      __type__: 'reference',
+      path: 'users/jeff/tasks/my_task_id',
+    })).toBe(base + 44);
+    expect(estimateSingleFieldDocumentBytes({ __type__: 'bytes', base64: 'AQIDBA==' })).toBe(
+      base + 4,
+    );
+    expect(estimateSingleFieldDocumentBytes({ __type__: 'vector', value: [0, 1, 2] })).toBe(
+      base + 24,
+    );
+  });
+
+  it('sums array values without extra array overhead', () => {
+    const base = DOCUMENT_OVERHEAD_BYTES + VALUE_FIELD_NAME_BYTES;
+    expect(estimateSingleFieldDocumentBytes([true, null, 'λ', 7])).toBe(base + 13);
+    expect(estimateSingleFieldDocumentBytes({ __type__: 'array', value: [false, 'ok'] })).toBe(
+      base + 4,
+    );
+  });
+
+  it('adds 32 bytes plus field names and values for maps', () => {
+    const base = DOCUMENT_OVERHEAD_BYTES + VALUE_FIELD_NAME_BYTES;
+    expect(estimateSingleFieldDocumentBytes({ done: false })).toBe(base + 38);
+    expect(estimateSingleFieldDocumentBytes({ __type__: 'map', value: { done: false } })).toBe(
+      base + 38,
+    );
+  });
+
+  it('matches the documented document-size example', () => {
+    expect(estimateFirestoreDocumentBytes(
+      {
+        description: 'Learn Cloud Firestore',
+        done: false,
+        priority: 1,
+        type: 'Personal',
       },
-    })).toBe(196);
+      { documentPath: 'users/jeff/tasks/my_task_id' },
+    )).toBe(147);
   });
 });

--- a/packages/repo-contracts/src/firestore.test.ts
+++ b/packages/repo-contracts/src/firestore.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   assertFirestoreCollectionPath,
   assertFirestoreDocumentPath,
+  estimateFirestoreDocumentBytes,
   firestorePathParts,
   isFirestoreCollectionPath,
   isFirestoreDocumentPath,
@@ -26,5 +27,24 @@ describe('Firestore path helpers', () => {
     expect(() => assertFirestoreDocumentPath('orders')).toThrow(
       'Invalid Firestore document path: orders',
     );
+  });
+});
+
+describe('Firestore document size estimates', () => {
+  it('estimates nested document bytes without runtime-specific APIs', () => {
+    expect(estimateFirestoreDocumentBytes({
+      active: true,
+      name: 'Ada',
+      tags: ['x', 'λ'],
+    })).toBe(191);
+  });
+
+  it('accounts for multibyte strings and nested object keys', () => {
+    expect(estimateFirestoreDocumentBytes({
+      meta: {
+        emoji: '🔥',
+        score: 12,
+      },
+    })).toBe(196);
   });
 });

--- a/packages/repo-contracts/src/firestore.ts
+++ b/packages/repo-contracts/src/firestore.ts
@@ -1,6 +1,8 @@
 import type { Page, PageRequest } from './pagination.ts';
 import type { FirestoreFieldStaleBehavior } from './settings.ts';
 
+const FIRESTORE_ESTIMATED_FIELD_OVERHEAD_BYTES = 32;
+
 export interface FirestoreCollectionNode {
   readonly path: string;
   readonly id: string;
@@ -195,4 +197,48 @@ export function isFirestoreDocumentPath(path: string): boolean {
 export function firestorePathParts(path: string): ReadonlyArray<string> {
   const parts = path.split('/');
   return parts.some((part) => part.length === 0) ? [] : parts;
+}
+
+export function estimateFirestoreDocumentBytes(data: Record<string, unknown>): number {
+  return estimateFirestoreValueBytes(data);
+}
+
+function estimateFirestoreValueBytes(value: unknown): number {
+  if (value === null || value === undefined) return 4;
+  if (typeof value === 'string') return utf8ByteLength(value) + 2;
+  if (typeof value === 'number') return 16;
+  if (typeof value === 'boolean') return 5;
+  if (Array.isArray(value)) {
+    return FIRESTORE_ESTIMATED_FIELD_OVERHEAD_BYTES
+      + value.reduce((total, item) => total + estimateFirestoreValueBytes(item), 0);
+  }
+  if (isPlainObject(value)) {
+    return FIRESTORE_ESTIMATED_FIELD_OVERHEAD_BYTES
+      + Object.entries(value).reduce(
+        (total, [key, item]) =>
+          total
+          + utf8ByteLength(key)
+          + FIRESTORE_ESTIMATED_FIELD_OVERHEAD_BYTES
+          + estimateFirestoreValueBytes(item),
+        0,
+      );
+  }
+  return FIRESTORE_ESTIMATED_FIELD_OVERHEAD_BYTES;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function utf8ByteLength(value: string): number {
+  let bytes = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const codePoint = value.codePointAt(index) ?? 0;
+    if (codePoint > 0xffff) index += 1;
+    if (codePoint <= 0x7f) bytes += 1;
+    else if (codePoint <= 0x7ff) bytes += 2;
+    else if (codePoint <= 0xffff) bytes += 3;
+    else bytes += 4;
+  }
+  return bytes;
 }

--- a/packages/repo-contracts/src/firestore.ts
+++ b/packages/repo-contracts/src/firestore.ts
@@ -1,7 +1,8 @@
 import type { Page, PageRequest } from './pagination.ts';
 import type { FirestoreFieldStaleBehavior } from './settings.ts';
 
-const FIRESTORE_ESTIMATED_FIELD_OVERHEAD_BYTES = 32;
+const FIRESTORE_DOCUMENT_OVERHEAD_BYTES = 32;
+const FIRESTORE_DOCUMENT_NAME_OVERHEAD_BYTES = 16;
 
 export interface FirestoreCollectionNode {
   readonly path: string;
@@ -199,31 +200,82 @@ export function firestorePathParts(path: string): ReadonlyArray<string> {
   return parts.some((part) => part.length === 0) ? [] : parts;
 }
 
-export function estimateFirestoreDocumentBytes(data: Record<string, unknown>): number {
-  return estimateFirestoreValueBytes(data);
+export interface FirestoreDocumentSizeEstimateOptions {
+  readonly documentPath?: string | undefined;
+}
+
+export function estimateFirestoreDocumentBytes(
+  data: Record<string, unknown>,
+  options: FirestoreDocumentSizeEstimateOptions = {},
+): number {
+  // Mirrors Firestore storage-size rules; excludes index entry storage and write RPC overhead.
+  return estimateFirestoreMapBytes(data)
+    + (options.documentPath ? estimateFirestoreDocumentNameBytes(options.documentPath) : 0);
+}
+
+function estimateFirestoreDocumentNameBytes(path: string): number {
+  return firestorePathParts(path).reduce(
+    (total, part) => total + estimateFirestoreStringBytes(part),
+    FIRESTORE_DOCUMENT_NAME_OVERHEAD_BYTES,
+  );
 }
 
 function estimateFirestoreValueBytes(value: unknown): number {
-  if (value === null || value === undefined) return 4;
-  if (typeof value === 'string') return utf8ByteLength(value) + 2;
-  if (typeof value === 'number') return 16;
-  if (typeof value === 'boolean') return 5;
+  if (value === undefined) return 0;
+  if (value === null) return 1;
+  if (typeof value === 'string') return estimateFirestoreStringBytes(value);
+  if (typeof value === 'number') return 8;
+  if (typeof value === 'boolean') return 1;
+  if (value instanceof Date) return 8;
+  if (value instanceof ArrayBuffer) return value.byteLength;
+  if (ArrayBuffer.isView(value)) return value.byteLength;
   if (Array.isArray(value)) {
-    return FIRESTORE_ESTIMATED_FIELD_OVERHEAD_BYTES
-      + value.reduce((total, item) => total + estimateFirestoreValueBytes(item), 0);
+    return value.reduce((total, item) => total + estimateFirestoreValueBytes(item), 0);
   }
   if (isPlainObject(value)) {
-    return FIRESTORE_ESTIMATED_FIELD_OVERHEAD_BYTES
-      + Object.entries(value).reduce(
-        (total, [key, item]) =>
-          total
-          + utf8ByteLength(key)
-          + FIRESTORE_ESTIMATED_FIELD_OVERHEAD_BYTES
-          + estimateFirestoreValueBytes(item),
-        0,
-      );
+    const taggedSize = estimateFirestoreTaggedValueBytes(value);
+    return taggedSize ?? estimateFirestoreMapBytes(value);
   }
-  return FIRESTORE_ESTIMATED_FIELD_OVERHEAD_BYTES;
+  return 0;
+}
+
+function estimateFirestoreStringBytes(value: string): number {
+  return utf8ByteLength(value) + 1;
+}
+
+function estimateFirestoreMapBytes(value: Record<string, unknown>): number {
+  return FIRESTORE_DOCUMENT_OVERHEAD_BYTES
+    + Object.entries(value).reduce(
+      (total, [key, item]) => {
+        if (item === undefined) return total;
+        return total
+          + estimateFirestoreStringBytes(key)
+          + estimateFirestoreValueBytes(item);
+      },
+      0,
+    );
+}
+
+function estimateFirestoreTaggedValueBytes(value: Record<string, unknown>): number | undefined {
+  switch (value['__type__']) {
+    case 'timestamp':
+      return 8;
+    case 'geoPoint':
+      return 16;
+    case 'reference':
+      return typeof value['path'] === 'string'
+        ? estimateFirestoreDocumentNameBytes(value['path'])
+        : 0;
+    case 'bytes':
+      return typeof value['base64'] === 'string' ? base64ByteLength(value['base64']) : 0;
+    case 'array':
+      return Array.isArray(value['value']) ? estimateFirestoreValueBytes(value['value']) : 0;
+    case 'map':
+      return isPlainObject(value['value']) ? estimateFirestoreMapBytes(value['value']) : 0;
+    case 'vector':
+      return Array.isArray(value['value']) ? value['value'].length * 8 : 0;
+  }
+  return undefined;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -241,4 +293,11 @@ function utf8ByteLength(value: string): number {
     else bytes += 4;
   }
   return bytes;
+}
+
+function base64ByteLength(value: string): number {
+  const normalized = value.replace(/\s/g, '');
+  if (!normalized) return 0;
+  const padding = normalized.endsWith('==') ? 2 : normalized.endsWith('=') ? 1 : 0;
+  return Math.max(0, Math.floor(normalized.length * 3 / 4) - padding);
 }


### PR DESCRIPTION
## What
- Add native app/edit/window menus and input context menus.
- Open external links in system browser; keep dev controls dev-only.
- Add draggable macOS titlebar regions and min window size.
- Persist/restore main window bounds with off-screen correction.
- Notify completed background jobs only when app unfocused.
- Bump app version to 0.0.3.

Closes #31
Closes #33
Closes #34
Closes #35
Closes #45
Refs #29
Refs #40

## Checks
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
