### PR TITLE
[codex] native app polish

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebase-desk/desktop",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "license": "MIT",
   "description": "Firebase Desk Electron application.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-desk",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "description": "Firebase Desk monorepo root.",
   "license": "MIT",

--- a/packages/product-ui/src/features/auth/AuthUsersSurface.test.tsx
+++ b/packages/product-ui/src/features/auth/AuthUsersSurface.test.tsx
@@ -1,7 +1,7 @@
 import { AUTH_USERS, MockSettingsRepository } from '@firebase-desk/repo-mocks';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppearanceProvider } from '../../appearance/AppearanceProvider.tsx';
 import { AuthUsersSurface } from './AuthUsersSurface.tsx';
 
@@ -37,6 +37,10 @@ describe('AuthUsersSurface', () => {
         removeEventListener: vi.fn(),
       })),
     );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('renders provided users, selects users, and exposes Load more', () => {
@@ -128,6 +132,32 @@ describe('AuthUsersSurface', () => {
 
     expect(await screen.findByText('Custom claims JSON must be an object.')).toBeTruthy();
     expect(onSaveCustomClaims).not.toHaveBeenCalled();
+  });
+
+  it('guards dirty custom claims before closing', async () => {
+    const confirm = vi.fn(() => false);
+    vi.stubGlobal('confirm', confirm);
+    renderWithAppearance(
+      <AuthUsersSurface
+        filterValue=''
+        hasMore={false}
+        selectedUserId='u_ada'
+        users={[AUTH_USERS[0]!]}
+        onFilterChange={() => {}}
+        onLoadMore={() => {}}
+        onSaveCustomClaims={() => {}}
+        onSelectUser={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(await screen.findByTestId('monaco'), {
+      target: { value: '{ "role": "owner" }' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(confirm).toHaveBeenCalledWith('Discard unsaved custom claims changes?');
+    expect(screen.getByRole('dialog', { name: 'Custom claims' })).toBeTruthy();
   });
 
   it('surfaces custom claims save errors', async () => {

--- a/packages/product-ui/src/features/auth/AuthUsersSurface.tsx
+++ b/packages/product-ui/src/features/auth/AuthUsersSurface.tsx
@@ -22,6 +22,7 @@ import { useEffect, useState } from 'react';
 import { CodeEditor } from '../../code-editor/CodeEditor.tsx';
 import { useMediaQuery } from '../../hooks/useMediaQuery.ts';
 import { messageFromError } from '../../shared/errors.ts';
+import { confirmDiscardUnsavedChanges } from '../../shared/unsavedDialogGuard.ts';
 
 export interface AuthUsersSurfaceProps {
   readonly density?: DensityName | undefined;
@@ -326,7 +327,7 @@ function DetailItem({ label, value }: { readonly label: string; readonly value: 
       <span className='text-[11.5px] font-semibold uppercase tracking-normal text-text-muted'>
         {label}
       </span>
-      <span className='min-w-0 overflow-hidden text-ellipsis break-words font-medium text-text-primary'>
+      <span className='min-w-0 select-text overflow-hidden text-ellipsis break-words font-medium text-text-primary'>
         {value}
       </span>
     </div>
@@ -357,19 +358,32 @@ function ClaimsEditorModal(
   },
 ) {
   const [source, setSource] = useState('{}');
+  const [baselineSource, setBaselineSource] = useState('{}');
   const [error, setError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
     if (open && user) {
-      setSource(JSON.stringify(user.customClaims, null, 2));
+      const nextSource = JSON.stringify(user.customClaims, null, 2);
+      setBaselineSource(nextSource);
+      setSource(nextSource);
       setError(null);
       setIsSaving(false);
     }
   }, [open, user]);
 
+  const hasUnsavedChanges = source !== baselineSource;
+
+  function requestOpenChange(nextOpen: boolean) {
+    if (
+      !nextOpen && hasUnsavedChanges && !isSaving
+      && !confirmDiscardUnsavedChanges('Discard unsaved custom claims changes?')
+    ) return;
+    onOpenChange(nextOpen);
+  }
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={requestOpenChange}>
       <DialogContent
         className='w-[min(680px,calc(100vw-32px))]'
         description={user?.uid ?? null}
@@ -385,7 +399,7 @@ function ClaimsEditorModal(
         </div>
         {error ? <InlineAlert variant='danger'>{error}</InlineAlert> : null}
         <div className='flex justify-end gap-2'>
-          <Button disabled={isSaving} variant='ghost' onClick={() => onOpenChange(false)}>
+          <Button disabled={isSaving} variant='ghost' onClick={() => requestOpenChange(false)}>
             Cancel
           </Button>
           <Button

--- a/packages/product-ui/src/features/firestore/CreateDocumentModal.test.tsx
+++ b/packages/product-ui/src/features/firestore/CreateDocumentModal.test.tsx
@@ -1,6 +1,6 @@
 import { MockSettingsRepository } from '@firebase-desk/repo-mocks';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AppearanceProvider } from '../../appearance/AppearanceProvider.tsx';
 import { CreateDocumentModal } from './CreateDocumentModal.tsx';
 
@@ -18,6 +18,10 @@ vi.mock('../../code-editor/CodeEditor.tsx', () => ({
     />
   ),
 }));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('CreateDocumentModal', () => {
   it('generates an ID, allows override, and creates object JSON', async () => {
@@ -93,6 +97,32 @@ describe('CreateDocumentModal', () => {
         status: 'created',
       })
     );
+  });
+
+  it('guards dirty new document drafts before closing', async () => {
+    const confirm = vi.fn(() => false);
+    vi.stubGlobal('confirm', confirm);
+    const onOpenChange = vi.fn();
+    render(
+      <AppearanceProvider settings={new MockSettingsRepository()}>
+        <CreateDocumentModal
+          collectionPath='orders'
+          open
+          onCreateDocument={vi.fn<CreateDocument>()}
+          onGenerateDocumentId={() => 'generated_id'}
+          onOpenChange={onOpenChange}
+        />
+      </AppearanceProvider>,
+    );
+
+    expect(await screen.findByDisplayValue('generated_id')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('Document JSON'), {
+      target: { value: '{"status":"draft"}' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(confirm).toHaveBeenCalledWith('Discard the new document draft?');
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/product-ui/src/features/firestore/CreateDocumentModal.tsx
+++ b/packages/product-ui/src/features/firestore/CreateDocumentModal.tsx
@@ -2,6 +2,7 @@ import { Button, Dialog, DialogContent, InlineAlert, Input } from '@firebase-des
 import { useEffect, useRef, useState } from 'react';
 import { CodeEditor } from '../../code-editor/CodeEditor.tsx';
 import { messageFromError } from '../../shared/errors.ts';
+import { confirmDiscardUnsavedChanges } from '../../shared/unsavedDialogGuard.ts';
 import { parseDocumentJson, validateFirestoreDocumentData } from './fieldEditModel.ts';
 
 export interface CreateDocumentModalProps {
@@ -74,8 +75,23 @@ export function CreateDocumentModal(
     };
   }, [draftCollectionPath, onGenerateDocumentId, open]);
 
+  const hasUnsavedChanges = source !== '{}'
+    || idTouched.current
+    || (
+      collectionPathEditable
+      && normalizePath(draftCollectionPath) !== normalizePath(collectionPath ?? '')
+    );
+
+  function requestOpenChange(nextOpen: boolean) {
+    if (
+      !nextOpen && hasUnsavedChanges && !isSaving
+      && !confirmDiscardUnsavedChanges('Discard the new document draft?')
+    ) return;
+    onOpenChange(nextOpen);
+  }
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={requestOpenChange}>
       <DialogContent
         className='w-[min(760px,calc(100vw-32px))]'
         description={collectionPathEditable ? 'Create the first document' : collectionPath}
@@ -130,7 +146,7 @@ export function CreateDocumentModal(
           {error ? <InlineAlert variant='danger'>{error}</InlineAlert> : null}
         </div>
         <div className='flex justify-end gap-2'>
-          <Button disabled={isSaving} variant='ghost' onClick={() => onOpenChange(false)}>
+          <Button disabled={isSaving} variant='ghost' onClick={() => requestOpenChange(false)}>
             Cancel
           </Button>
           <Button

--- a/packages/product-ui/src/features/firestore/DocumentEditorModal.test.tsx
+++ b/packages/product-ui/src/features/firestore/DocumentEditorModal.test.tsx
@@ -1,6 +1,6 @@
 import type { FirestoreDocumentResult } from '@firebase-desk/repo-contracts';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DocumentEditorModal } from './DocumentEditorModal.tsx';
 
 vi.mock('../../code-editor/CodeEditor.tsx', () => ({
@@ -24,6 +24,10 @@ const document: FirestoreDocumentResult = {
   data: { status: 'paid' },
   hasSubcollections: false,
 };
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('DocumentEditorModal', () => {
   it('saves document JSON', async () => {
@@ -68,5 +72,27 @@ describe('DocumentEditorModal', () => {
 
     expect(await screen.findByText('Document JSON must be an object.')).toBeTruthy();
     expect(onSaveDocument).not.toHaveBeenCalled();
+  });
+
+  it('guards dirty document edits before closing', () => {
+    const confirm = vi.fn(() => false);
+    vi.stubGlobal('confirm', confirm);
+    const onOpenChange = vi.fn();
+    render(
+      <DocumentEditorModal
+        document={document}
+        open
+        onOpenChange={onOpenChange}
+        onSaveDocument={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Document JSON'), {
+      target: { value: '{ "status": "draft" }' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(confirm).toHaveBeenCalledWith('Discard unsaved document changes?');
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/product-ui/src/features/firestore/DocumentEditorModal.tsx
+++ b/packages/product-ui/src/features/firestore/DocumentEditorModal.tsx
@@ -3,6 +3,7 @@ import { Button, Dialog, DialogContent, InlineAlert } from '@firebase-desk/ui';
 import { useEffect, useState } from 'react';
 import { CodeEditor } from '../../code-editor/CodeEditor.tsx';
 import { messageFromError } from '../../shared/errors.ts';
+import { confirmDiscardUnsavedChanges } from '../../shared/unsavedDialogGuard.ts';
 import { parseDocumentJson, validateFirestoreDocumentData } from './fieldEditModel.ts';
 
 export interface DocumentEditorModalProps {
@@ -21,19 +22,32 @@ export function DocumentEditorModal(
   { document, onSaveDocument, onOpenChange, open }: DocumentEditorModalProps,
 ) {
   const [source, setSource] = useState('{}');
+  const [baselineSource, setBaselineSource] = useState('{}');
   const [error, setError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
     if (document) {
-      setSource(JSON.stringify(document.data, null, 2));
+      const nextSource = JSON.stringify(document.data, null, 2);
+      setBaselineSource(nextSource);
+      setSource(nextSource);
       setError(null);
       setIsSaving(false);
     }
   }, [document]);
 
+  const hasUnsavedChanges = source !== baselineSource;
+
+  function requestOpenChange(nextOpen: boolean) {
+    if (
+      !nextOpen && hasUnsavedChanges && !isSaving
+      && !confirmDiscardUnsavedChanges('Discard unsaved document changes?')
+    ) return;
+    onOpenChange(nextOpen);
+  }
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={requestOpenChange}>
       <DialogContent
         className='w-[min(760px,calc(100vw-32px))]'
         description={document?.path ?? null}
@@ -51,7 +65,7 @@ export function DocumentEditorModal(
         </div>
         {error ? <InlineAlert variant='danger'>{error}</InlineAlert> : null}
         <div className='flex justify-end gap-2'>
-          <Button disabled={isSaving} variant='ghost' onClick={() => onOpenChange(false)}>
+          <Button disabled={isSaving} variant='ghost' onClick={() => requestOpenChange(false)}>
             Cancel
           </Button>
           <Button

--- a/packages/product-ui/src/features/firestore/FieldEditModal.test.tsx
+++ b/packages/product-ui/src/features/firestore/FieldEditModal.test.tsx
@@ -1,7 +1,7 @@
 import { FirestoreTimestamp } from '@firebase-desk/data-format';
 import { MockSettingsRepository } from '@firebase-desk/repo-mocks';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AppearanceProvider } from '../../appearance/AppearanceProvider.tsx';
 import { FieldEditModal } from './FieldEditModal.tsx';
 import type { FieldEditTarget } from './fieldEditModel.ts';
@@ -20,6 +20,10 @@ vi.mock('../../code-editor/CodeEditor.tsx', () => ({
     />
   ),
 }));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('FieldEditModal', () => {
   it('changes a boolean field to a number', async () => {
@@ -65,6 +69,28 @@ describe('FieldEditModal', () => {
     expect((await screen.findByRole('alert')).textContent).toMatch(/Expected property name|JSON/);
     expect(onSaveField).not.toHaveBeenCalled();
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it('guards dirty field edits before closing', () => {
+    const confirm = vi.fn(() => false);
+    vi.stubGlobal('confirm', confirm);
+    const onOpenChange = vi.fn();
+    render(
+      <AppearanceProvider settings={new MockSettingsRepository()}>
+        <FieldEditModal
+          open
+          target={{ documentPath: 'orders/ord_1', fieldPath: ['active'], value: true }}
+          onOpenChange={onOpenChange}
+          onSaveField={() => {}}
+        />
+      </AppearanceProvider>,
+    );
+
+    fireEvent.change(screen.getByLabelText('Type'), { target: { value: 'number' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(confirm).toHaveBeenCalledWith('Discard unsaved field changes?');
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 
   it('edits timestamps with a local date time input', async () => {

--- a/packages/product-ui/src/features/firestore/FieldEditModal.tsx
+++ b/packages/product-ui/src/features/firestore/FieldEditModal.tsx
@@ -2,6 +2,7 @@ import { Button, Dialog, DialogContent, InlineAlert, Input } from '@firebase-des
 import { useEffect, useMemo, useState } from 'react';
 import { CodeEditor } from '../../code-editor/CodeEditor.tsx';
 import { messageFromError } from '../../shared/errors.ts';
+import { confirmDiscardUnsavedChanges } from '../../shared/unsavedDialogGuard.ts';
 import {
   classifyFieldValue,
   defaultValueForType,
@@ -37,14 +38,19 @@ export function FieldEditModal(
   );
   const [type, setType] = useState<FirestoreEditableType>(initialType);
   const [source, setSource] = useState('null');
+  const [baselineSource, setBaselineSource] = useState('null');
+  const [baselineType, setBaselineType] = useState<FirestoreEditableType>(initialType);
   const [error, setError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
     if (!target) return;
     const nextType = classifyFieldValue(target.value).type;
+    const nextSource = JSON.stringify(normalizeEditableValue(target.value), null, 2);
+    setBaselineType(nextType);
+    setBaselineSource(nextSource);
     setType(nextType);
-    setSource(JSON.stringify(normalizeEditableValue(target.value), null, 2));
+    setSource(nextSource);
     setError(null);
     setIsSaving(false);
   }, [target]);
@@ -61,9 +67,18 @@ export function FieldEditModal(
 
   const parsedValue = safeParse(source);
   const showJsonEditor = type === 'array' || type === 'map';
+  const hasUnsavedChanges = type !== baselineType || source !== baselineSource;
+
+  function requestOpenChange(nextOpen: boolean) {
+    if (
+      !nextOpen && hasUnsavedChanges && !isSaving
+      && !confirmDiscardUnsavedChanges('Discard unsaved field changes?')
+    ) return;
+    onOpenChange(nextOpen);
+  }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={requestOpenChange}>
       <DialogContent
         className='w-[min(680px,calc(100vw-32px))]'
         description={target ? target.documentPath : null}
@@ -115,7 +130,7 @@ export function FieldEditModal(
           {error ? <InlineAlert variant='danger'>{error}</InlineAlert> : null}
         </div>
         <div className='flex justify-end gap-2'>
-          <Button disabled={isSaving} variant='ghost' onClick={() => onOpenChange(false)}>
+          <Button disabled={isSaving} variant='ghost' onClick={() => requestOpenChange(false)}>
             Cancel
           </Button>
           <Button

--- a/packages/product-ui/src/features/firestore/FirestoreDocumentBrowser.test.tsx
+++ b/packages/product-ui/src/features/firestore/FirestoreDocumentBrowser.test.tsx
@@ -1,4 +1,4 @@
-import type { FirestoreDocumentResult } from '@firebase-desk/repo-contracts';
+import type { FirestoreDocumentResult, SettingsRepository } from '@firebase-desk/repo-contracts';
 import { MockSettingsRepository } from '@firebase-desk/repo-mocks';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
@@ -132,4 +132,45 @@ describe('FirestoreDocumentBrowser', () => {
 
     await waitFor(() => expect(save).toHaveBeenCalledWith({ inspectorWidth: 512 }));
   });
+
+  it('keeps a user resize when settings load resolves late', async () => {
+    const snapshotSource = new MockSettingsRepository();
+    await snapshotSource.save({ inspectorWidth: 444 });
+    const load = deferred<Awaited<ReturnType<SettingsRepository['load']>>>();
+    const settings: SettingsRepository = {
+      load: vi.fn(() => load.promise),
+      save: vi.fn(async () => await snapshotSource.load()),
+      getHotkeyOverrides: vi.fn(async () => ({})),
+      setHotkeyOverrides: vi.fn(async () => {}),
+    };
+
+    render(
+      <FirestoreDocumentBrowser
+        hasMore={false}
+        queryPath='orders'
+        resultView='table'
+        rows={[]}
+        settings={settings}
+        onLoadMore={() => {}}
+        onResultViewChange={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'resize 360px' }));
+    await waitFor(() => expect(screen.getByTestId('panel-512px')).toBeTruthy());
+
+    load.resolve(await snapshotSource.load());
+    await Promise.resolve();
+
+    expect(screen.queryByTestId('panel-444px')).toBeNull();
+    expect(screen.getByTestId('panel-512px')).toBeTruthy();
+  });
 });
+
+function deferred<T>(): { readonly promise: Promise<T>; readonly resolve: (value: T) => void; } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolver) => {
+    resolve = resolver;
+  });
+  return { promise, resolve };
+}

--- a/packages/product-ui/src/features/firestore/FirestoreDocumentBrowser.test.tsx
+++ b/packages/product-ui/src/features/firestore/FirestoreDocumentBrowser.test.tsx
@@ -1,4 +1,5 @@
 import type { FirestoreDocumentResult } from '@firebase-desk/repo-contracts';
+import { MockSettingsRepository } from '@firebase-desk/repo-mocks';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -15,7 +16,29 @@ vi.mock('@firebase-desk/ui', async (importOriginal) => {
   return {
     ...actual,
     ResizablePanelGroup: ({ children }: { readonly children: ReactNode; }) => <div>{children}</div>,
-    ResizablePanel: ({ children }: { readonly children: ReactNode; }) => <div>{children}</div>,
+    ResizablePanel: (
+      {
+        children,
+        defaultSize,
+        onResize,
+      }: {
+        readonly children: ReactNode;
+        readonly defaultSize?: string | number | undefined;
+        readonly onResize?: (
+          size: { readonly inPixels: number; readonly percentage: number; },
+        ) => void;
+      },
+    ) => (
+      <div data-testid={`panel-${String(defaultSize ?? 'auto')}`}>
+        <button
+          type='button'
+          onClick={() => onResize?.({ inPixels: 512, percentage: 30 })}
+        >
+          resize {String(defaultSize ?? 'auto')}
+        </button>
+        {children}
+      </div>
+    ),
     ResizableHandle: () => null,
   };
 });
@@ -84,5 +107,29 @@ describe('FirestoreDocumentBrowser', () => {
     );
     expect(onLoadSubcollections).toHaveBeenCalledWith('orders/ord_1');
     expect(screen.getByTestId('overview').textContent).toBe('table:orders/ord_1');
+  });
+
+  it('restores and saves the inspector pane width', async () => {
+    const settings = new MockSettingsRepository();
+    await settings.save({ inspectorWidth: 444 });
+    const save = vi.spyOn(settings, 'save');
+
+    render(
+      <FirestoreDocumentBrowser
+        hasMore={false}
+        queryPath='orders'
+        resultView='table'
+        rows={[]}
+        settings={settings}
+        onLoadMore={() => {}}
+        onResultViewChange={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('panel-444px')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: 'resize 444px' }));
+
+    await waitFor(() => expect(save).toHaveBeenCalledWith({ inspectorWidth: 512 }));
   });
 });

--- a/packages/product-ui/src/features/firestore/FirestoreDocumentBrowser.tsx
+++ b/packages/product-ui/src/features/firestore/FirestoreDocumentBrowser.tsx
@@ -5,7 +5,7 @@ import type {
   SettingsRepository,
 } from '@firebase-desk/repo-contracts';
 import { cn, ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@firebase-desk/ui';
-import { type ReactNode, useMemo, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import { useMediaQuery } from '../../hooks/useMediaQuery.ts';
 import { messageFromError } from '../../shared/errors.ts';
 import { type FieldEditTarget } from './fieldEditModel.ts';
@@ -19,6 +19,10 @@ import { ResultPanel } from './ResultPanel.tsx';
 import type { FirestoreResultView } from './types.ts';
 
 type CollectionJobKind = 'copy' | 'delete' | 'duplicate' | 'export' | 'import';
+
+const DEFAULT_INSPECTOR_WIDTH = 360;
+const MIN_INSPECTOR_WIDTH = 280;
+const MAX_INSPECTOR_WIDTH = 520;
 
 export interface FirestoreDocumentBrowserProps {
   readonly className?: string;
@@ -96,6 +100,8 @@ export function FirestoreDocumentBrowser(
   }: FirestoreDocumentBrowserProps,
 ) {
   const [overviewCollapsed, setOverviewCollapsed] = useState(false);
+  const [inspectorWidth, setInspectorWidth] = useState(DEFAULT_INSPECTOR_WIDTH);
+  const [inspectorLayoutRevision, setInspectorLayoutRevision] = useState(0);
   const [subcollectionStates, setSubcollectionStates] = useState<
     Readonly<Record<string, SubcollectionLoadState>>
   >({});
@@ -113,6 +119,27 @@ export function FirestoreDocumentBrowser(
       ? findDocumentByPath(rowsWithSubcollections, selectedDocumentPath) ?? fallback
       : fallback;
   }, [rowsWithSubcollections, selectedDocument, selectedDocumentPath, subcollectionStates]);
+
+  useEffect(() => {
+    if (!settings) {
+      setInspectorWidth(DEFAULT_INSPECTOR_WIDTH);
+      setInspectorLayoutRevision((revision) => revision + 1);
+      return;
+    }
+    let cancelled = false;
+    settings.load().then((snapshot) => {
+      if (cancelled) return;
+      setInspectorWidth(clampInspectorWidth(snapshot.inspectorWidth));
+      setInspectorLayoutRevision((revision) => revision + 1);
+    }).catch((caught) => {
+      if (!cancelled) {
+        onSettingsError?.(messageFromError(caught, 'Could not load inspector layout settings.'));
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [onSettingsError, settings]);
 
   async function loadSubcollections(documentPath: string) {
     if (!onLoadSubcollections) return;
@@ -135,6 +162,15 @@ export function FirestoreDocumentBrowser(
         },
       }));
     }
+  }
+
+  function saveInspectorWidth(width: number) {
+    const nextWidth = clampInspectorWidth(width);
+    setInspectorWidth(nextWidth);
+    if (!settings) return;
+    void settings.save({ inspectorWidth: nextWidth }).catch((caught) => {
+      onSettingsError?.(messageFromError(caught, 'Could not save inspector layout settings.'));
+    });
   }
 
   const mainColumn = (
@@ -200,7 +236,9 @@ export function FirestoreDocumentBrowser(
       {useSplitLayout
         ? (
           <ResizablePanelGroup
-            key={overviewCollapsed ? 'overview-collapsed' : 'overview-expanded'}
+            key={`${
+              overviewCollapsed ? 'overview-collapsed' : 'overview-expanded'
+            }:${inspectorLayoutRevision}`}
             direction='horizontal'
             className='h-full min-h-0'
           >
@@ -210,9 +248,13 @@ export function FirestoreDocumentBrowser(
             <ResizableHandle className='mx-2 h-full w-px' />
             <ResizablePanel
               className='flex h-full min-h-0 flex-col'
-              defaultSize={overviewCollapsed ? '42px' : '34%'}
+              defaultSize={overviewCollapsed ? '42px' : `${inspectorWidth}px`}
+              groupResizeBehavior='preserve-pixel-size'
               maxSize={overviewCollapsed ? '42px' : '520px'}
               minSize={overviewCollapsed ? '42px' : '280px'}
+              onResize={(size) => {
+                if (!overviewCollapsed) saveInspectorWidth(size.inPixels);
+              }}
             >
               {overviewPanel}
             </ResizablePanel>
@@ -226,4 +268,9 @@ export function FirestoreDocumentBrowser(
         )}
     </div>
   );
+}
+
+function clampInspectorWidth(width: number): number {
+  if (!Number.isFinite(width)) return DEFAULT_INSPECTOR_WIDTH;
+  return Math.min(MAX_INSPECTOR_WIDTH, Math.max(MIN_INSPECTOR_WIDTH, Math.round(width)));
 }

--- a/packages/product-ui/src/features/firestore/FirestoreDocumentBrowser.tsx
+++ b/packages/product-ui/src/features/firestore/FirestoreDocumentBrowser.tsx
@@ -5,7 +5,7 @@ import type {
   SettingsRepository,
 } from '@firebase-desk/repo-contracts';
 import { cn, ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@firebase-desk/ui';
-import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { useMediaQuery } from '../../hooks/useMediaQuery.ts';
 import { messageFromError } from '../../shared/errors.ts';
 import { type FieldEditTarget } from './fieldEditModel.ts';
@@ -21,6 +21,7 @@ import type { FirestoreResultView } from './types.ts';
 type CollectionJobKind = 'copy' | 'delete' | 'duplicate' | 'export' | 'import';
 
 const DEFAULT_INSPECTOR_WIDTH = 360;
+const COLLAPSED_INSPECTOR_WIDTH = 42;
 const MIN_INSPECTOR_WIDTH = 280;
 const MAX_INSPECTOR_WIDTH = 520;
 
@@ -102,6 +103,7 @@ export function FirestoreDocumentBrowser(
   const [overviewCollapsed, setOverviewCollapsed] = useState(false);
   const [inspectorWidth, setInspectorWidth] = useState(DEFAULT_INSPECTOR_WIDTH);
   const [inspectorLayoutRevision, setInspectorLayoutRevision] = useState(0);
+  const inspectorInteractionVersion = useRef(0);
   const [subcollectionStates, setSubcollectionStates] = useState<
     Readonly<Record<string, SubcollectionLoadState>>
   >({});
@@ -127,8 +129,9 @@ export function FirestoreDocumentBrowser(
       return;
     }
     let cancelled = false;
+    const loadInteractionVersion = inspectorInteractionVersion.current;
     settings.load().then((snapshot) => {
-      if (cancelled) return;
+      if (cancelled || inspectorInteractionVersion.current !== loadInteractionVersion) return;
       setInspectorWidth(clampInspectorWidth(snapshot.inspectorWidth));
       setInspectorLayoutRevision((revision) => revision + 1);
     }).catch((caught) => {
@@ -166,6 +169,7 @@ export function FirestoreDocumentBrowser(
 
   function saveInspectorWidth(width: number) {
     const nextWidth = clampInspectorWidth(width);
+    inspectorInteractionVersion.current += 1;
     setInspectorWidth(nextWidth);
     if (!settings) return;
     void settings.save({ inspectorWidth: nextWidth }).catch((caught) => {
@@ -248,10 +252,16 @@ export function FirestoreDocumentBrowser(
             <ResizableHandle className='mx-2 h-full w-px' />
             <ResizablePanel
               className='flex h-full min-h-0 flex-col'
-              defaultSize={overviewCollapsed ? '42px' : `${inspectorWidth}px`}
+              defaultSize={overviewCollapsed
+                ? `${COLLAPSED_INSPECTOR_WIDTH}px`
+                : `${inspectorWidth}px`}
               groupResizeBehavior='preserve-pixel-size'
-              maxSize={overviewCollapsed ? '42px' : '520px'}
-              minSize={overviewCollapsed ? '42px' : '280px'}
+              maxSize={overviewCollapsed
+                ? `${COLLAPSED_INSPECTOR_WIDTH}px`
+                : `${MAX_INSPECTOR_WIDTH}px`}
+              minSize={overviewCollapsed
+                ? `${COLLAPSED_INSPECTOR_WIDTH}px`
+                : `${MIN_INSPECTOR_WIDTH}px`}
               onResize={(size) => {
                 if (!overviewCollapsed) saveInspectorWidth(size.inPixels);
               }}

--- a/packages/product-ui/src/shared/unsavedDialogGuard.ts
+++ b/packages/product-ui/src/shared/unsavedDialogGuard.ts
@@ -1,0 +1,3 @@
+export function confirmDiscardUnsavedChanges(message: string): boolean {
+  return globalThis.confirm?.(message) ?? true;
+}


### PR DESCRIPTION
## What
- Bump app version to 0.0.4.
- Persist Firestore inspector pane width in app settings.
- Guard dirty document, field, create-document, and custom-claims dialogs before close.
- Keep auth detail values selectable for copy flows.

## Why
Rounds out native desktop behavior around persistent panes, explicit data-loss confirmation, and copy/select affordances.

## Resolved Issues
Closes #34
Closes #42

## Related
Refs #29, #30, #31, #32, #33, #35, #36, #37, #38, #39, #40, #41

## Validation
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
