### PR TITLE
native feel

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebase-desk/desktop",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "license": "MIT",
   "description": "Firebase Desk Electron application.",

--- a/apps/desktop/src/main/native-app.test.ts
+++ b/apps/desktop/src/main/native-app.test.ts
@@ -34,7 +34,7 @@ describe('native app behavior', () => {
     expect(nativeTheme.themeSource).toBe('system');
     expect(Menu.setApplicationMenu).toHaveBeenCalledTimes(1);
     if (process.platform === 'win32') {
-      expect(app.setAppUserModelId).toHaveBeenCalledWith('com.firebase-desk.app');
+      expect(app.setAppUserModelId).toHaveBeenCalledWith('dev.firebase-desk.app');
     } else {
       expect(app.setAppUserModelId).not.toHaveBeenCalled();
     }

--- a/apps/desktop/src/main/native-app.test.ts
+++ b/apps/desktop/src/main/native-app.test.ts
@@ -1,14 +1,18 @@
 import type { BackgroundJob } from '@firebase-desk/repo-contracts/jobs';
-import { type BrowserWindow, shell } from 'electron';
+import { app, type BrowserWindow, Menu, nativeTheme, shell } from 'electron';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createBackgroundJobNotifier, installNativeWindowBehavior } from './native-app.ts';
+import {
+  createBackgroundJobNotifier,
+  installNativeAppBehavior,
+  installNativeWindowBehavior,
+} from './native-app.ts';
 
 type ShowNotification = NonNullable<
   Parameters<typeof createBackgroundJobNotifier>[0]
 >['showNotification'];
 
 vi.mock('electron', () => ({
-  app: { isPackaged: true, name: 'Firebase Desk' },
+  app: { isPackaged: true, name: 'Firebase Desk', setAppUserModelId: vi.fn() },
   BrowserWindow: {
     getAllWindows: vi.fn(() => []),
     getFocusedWindow: vi.fn(() => null),
@@ -21,6 +25,20 @@ vi.mock('electron', () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+describe('native app behavior', () => {
+  it('installs native app identity and menus', () => {
+    installNativeAppBehavior();
+
+    expect(nativeTheme.themeSource).toBe('system');
+    expect(Menu.setApplicationMenu).toHaveBeenCalledTimes(1);
+    if (process.platform === 'win32') {
+      expect(app.setAppUserModelId).toHaveBeenCalledWith('com.firebase-desk.app');
+    } else {
+      expect(app.setAppUserModelId).not.toHaveBeenCalled();
+    }
+  });
 });
 
 describe('native window behavior', () => {

--- a/apps/desktop/src/main/native-app.ts
+++ b/apps/desktop/src/main/native-app.ts
@@ -35,7 +35,7 @@ interface BackgroundJobNotifierDeps {
 }
 
 const MAX_NOTIFIED_BACKGROUND_JOB_IDS = 500;
-const WINDOWS_APP_USER_MODEL_ID = 'com.firebase-desk.app';
+const WINDOWS_APP_USER_MODEL_ID = 'dev.firebase-desk.app';
 
 export function installNativeAppBehavior(): void {
   nativeTheme.themeSource = 'system';

--- a/apps/desktop/src/main/native-app.ts
+++ b/apps/desktop/src/main/native-app.ts
@@ -35,9 +35,11 @@ interface BackgroundJobNotifierDeps {
 }
 
 const MAX_NOTIFIED_BACKGROUND_JOB_IDS = 500;
+const WINDOWS_APP_USER_MODEL_ID = 'com.firebase-desk.app';
 
 export function installNativeAppBehavior(): void {
   nativeTheme.themeSource = 'system';
+  installPlatformAppIdentity();
   Menu.setApplicationMenu(Menu.buildFromTemplate(applicationMenuTemplate()));
 }
 
@@ -247,4 +249,9 @@ function openExternalSafely(url: string): void {
 
 function isDevelopmentRuntime(): boolean {
   return !app.isPackaged || Boolean(process.env['ELECTRON_RENDERER_URL']);
+}
+
+function installPlatformAppIdentity(): void {
+  if (process.platform !== 'win32') return;
+  app.setAppUserModelId(WINDOWS_APP_USER_MODEL_ID);
 }

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -38,7 +38,7 @@
     user-select: text;
   }
 
-  :where(button, a, [role='button'], [role='treeitem'], [role='tab'], [role='menuitem'], input, select, textarea):focus-visible {
+  :where(button, a, [role='button'], [role='row'], [role='treeitem'], [role='tab'], [role='menuitem'], input, select, textarea):focus-visible {
     outline: none;
     box-shadow: var(--focus-ring-shadow);
     border-radius: var(--radius-md);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-desk",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "description": "Firebase Desk monorepo root.",
   "license": "MIT",

--- a/packages/product-ui/src/activity/ActivityDrawer.test.tsx
+++ b/packages/product-ui/src/activity/ActivityDrawer.test.tsx
@@ -126,6 +126,31 @@ describe('ActivityDrawer', () => {
     expect(onExpandedChange).toHaveBeenCalledWith(false);
   });
 
+  it('closes on Escape from inside the drawer', () => {
+    const onClose = vi.fn();
+    render(
+      <ActivityDrawer
+        area='all'
+        entries={[]}
+        open
+        search=''
+        status='all'
+        onAreaChange={vi.fn()}
+        onClear={vi.fn()}
+        onClose={onClose}
+        onExport={vi.fn()}
+        onSearchChange={vi.fn()}
+        onStatusChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByRole('textbox', { name: 'Search activity' }), {
+      key: 'Escape',
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it('truncates very large payloads instead of freezing on JSON.stringify', () => {
     const huge: Record<string, string> = {};
     for (let i = 0; i < 50_000; i += 1) huge[`field_${i}`] = `value_${i}`;

--- a/packages/product-ui/src/activity/ActivityDrawer.tsx
+++ b/packages/product-ui/src/activity/ActivityDrawer.tsx
@@ -54,6 +54,10 @@ export function ActivityDrawer(
         'z-popover grid min-h-0',
         expanded ? 'h-[70vh] max-h-[720px]' : 'h-80',
       )}
+      tabIndex={-1}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') onClose();
+      }}
     >
       <header className='flex h-10 items-center gap-2 border-b border-border-subtle px-3'>
         <div className='min-w-0 flex-1'>

--- a/packages/product-ui/src/features/firestore/CollectionJobDialog.test.tsx
+++ b/packages/product-ui/src/features/firestore/CollectionJobDialog.test.tsx
@@ -93,6 +93,38 @@ describe('CollectionJobDialog', () => {
     );
   });
 
+  it('surfaces native picker failures without changing the path', async () => {
+    renderDialog({
+      initialKind: 'export',
+      onPickExportFile: async () => {
+        throw new Error('Save dialog failed');
+      },
+    });
+
+    const filePath = screen.getByRole('textbox', { name: 'Export file path' }) as HTMLInputElement;
+    expect(filePath.readOnly).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose' }));
+
+    expect(await screen.findByText('Save dialog failed')).toBeTruthy();
+    expect(filePath.value).toBe('');
+  });
+
+  it('treats picker cancel as no-op', async () => {
+    renderDialog({
+      initialKind: 'import',
+      onPickImportFile: async () => null,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose' }));
+
+    await waitFor(() => {
+      const input = screen.getByRole('textbox', { name: 'Import file path' }) as HTMLInputElement;
+      expect(input.value).toBe('');
+    });
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
   it('marks plain JSONL exports as export-only', () => {
     renderDialog({ initialKind: 'export' });
 

--- a/packages/product-ui/src/features/firestore/CollectionJobDialog.test.tsx
+++ b/packages/product-ui/src/features/firestore/CollectionJobDialog.test.tsx
@@ -125,6 +125,36 @@ describe('CollectionJobDialog', () => {
     expect(screen.queryByRole('alert')).toBeNull();
   });
 
+  it('clears stale export picker errors when a later picker is canceled', async () => {
+    const onPickExportFile = vi
+      .fn<NonNullable<ComponentProps<typeof CollectionJobDialog>['onPickExportFile']>>()
+      .mockRejectedValueOnce(new Error('Save dialog failed'))
+      .mockResolvedValueOnce(null);
+    renderDialog({ initialKind: 'export', onPickExportFile });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose' }));
+    expect(await screen.findByText('Save dialog failed')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose' }));
+
+    await waitFor(() => expect(screen.queryByRole('alert')).toBeNull());
+  });
+
+  it('clears stale import picker errors when a later picker is canceled', async () => {
+    const onPickImportFile = vi
+      .fn<NonNullable<ComponentProps<typeof CollectionJobDialog>['onPickImportFile']>>()
+      .mockRejectedValueOnce(new Error('Open dialog failed'))
+      .mockResolvedValueOnce(null);
+    renderDialog({ initialKind: 'import', onPickImportFile });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose' }));
+    expect(await screen.findByText('Open dialog failed')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose' }));
+
+    await waitFor(() => expect(screen.queryByRole('alert')).toBeNull());
+  });
+
   it('marks plain JSONL exports as export-only', () => {
     renderDialog({ initialKind: 'export' });
 

--- a/packages/product-ui/src/features/firestore/CollectionJobDialog.tsx
+++ b/packages/product-ui/src/features/firestore/CollectionJobDialog.tsx
@@ -65,13 +65,27 @@ export function CollectionJobDialog(
   }, [activeProject?.id, collectionPath, initialKind, open]);
 
   async function chooseExportFile() {
-    const picked = await onPickExportFile?.(format);
-    if (picked) setFilePath(picked);
+    try {
+      const picked = await onPickExportFile?.(format);
+      if (picked) {
+        setFilePath(picked);
+        setErrorMessage(null);
+      }
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Could not choose export file.');
+    }
   }
 
   async function chooseImportFile() {
-    const picked = await onPickImportFile?.();
-    if (picked) setFilePath(picked);
+    try {
+      const picked = await onPickImportFile?.();
+      if (picked) {
+        setFilePath(picked);
+        setErrorMessage(null);
+      }
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Could not choose import file.');
+    }
   }
 
   async function submit() {
@@ -316,8 +330,8 @@ export function CollectionJobDialog(
                   </span>
                   <Input
                     aria-label={kind === 'export' ? 'Export file path' : 'Import file path'}
+                    readOnly
                     value={filePath}
-                    onChange={(event) => setFilePath(event.currentTarget.value)}
                   />
                 </label>
                 <Button

--- a/packages/product-ui/src/features/firestore/CollectionJobDialog.tsx
+++ b/packages/product-ui/src/features/firestore/CollectionJobDialog.tsx
@@ -66,10 +66,10 @@ export function CollectionJobDialog(
 
   async function chooseExportFile() {
     try {
+      setErrorMessage(null);
       const picked = await onPickExportFile?.(format);
       if (picked) {
         setFilePath(picked);
-        setErrorMessage(null);
       }
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : 'Could not choose export file.');
@@ -78,10 +78,10 @@ export function CollectionJobDialog(
 
   async function chooseImportFile() {
     try {
+      setErrorMessage(null);
       const picked = await onPickImportFile?.();
       if (picked) {
         setFilePath(picked);
-        setErrorMessage(null);
       }
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : 'Could not choose import file.');

--- a/packages/product-ui/src/features/firestore/FirestoreDocumentBrowser.tsx
+++ b/packages/product-ui/src/features/firestore/FirestoreDocumentBrowser.tsx
@@ -58,6 +58,7 @@ export interface FirestoreDocumentBrowserProps {
   readonly onSetFieldNull?: ((target: FieldEditTarget) => void) | undefined;
   readonly queryPath: string;
   readonly resultView: FirestoreResultView;
+  readonly resultsScopeKey?: string | undefined;
   readonly resultsStale?: boolean;
   readonly rows: ReadonlyArray<FirestoreDocumentResult>;
   readonly selectedDocument?: FirestoreDocumentResult | null;
@@ -93,6 +94,7 @@ export function FirestoreDocumentBrowser(
     onSetFieldNull,
     queryPath,
     resultView,
+    resultsScopeKey,
     resultsStale = false,
     rows,
     selectedDocument = null,
@@ -194,6 +196,7 @@ export function FirestoreDocumentBrowser(
         actionNoticeMessage={actionNoticeMessage}
         queryPath={queryPath}
         resultView={resultView}
+        resultsScopeKey={resultsScopeKey ?? queryPath}
         resultsStale={resultsStale}
         rows={rowsWithSubcollections}
         selectedDocumentPath={selectedDocumentPath}

--- a/packages/product-ui/src/features/firestore/FirestoreQuerySurface.tsx
+++ b/packages/product-ui/src/features/firestore/FirestoreQuerySurface.tsx
@@ -538,6 +538,7 @@ export function FirestoreQuerySurface(
         actionNoticeMessage={actionNoticeMessage}
         queryPath={draft.path}
         resultView={effectiveResultView}
+        resultsScopeKey={resultsScopeKey}
         resultsStale={effectiveResultsStale}
         rows={rows}
         selectedDocument={selectedDocument}

--- a/packages/product-ui/src/features/firestore/ResultPanel.tsx
+++ b/packages/product-ui/src/features/firestore/ResultPanel.tsx
@@ -61,6 +61,7 @@ export interface ResultPanelProps {
   readonly onSetFieldNull?: ((target: FieldEditTarget) => void) | undefined;
   readonly queryPath: string;
   readonly resultView: FirestoreResultView;
+  readonly resultsScopeKey?: string | undefined;
   readonly rows: ReadonlyArray<FirestoreDocumentResult>;
   readonly selectedDocumentPath: string | null;
   readonly settings?: SettingsRepository | undefined;
@@ -93,6 +94,7 @@ export function ResultPanel(
     onSetFieldNull,
     queryPath,
     resultView,
+    resultsScopeKey,
     rows,
     selectedDocumentPath,
     settings,
@@ -260,6 +262,7 @@ export function ResultPanel(
                 hasMore={showPagination}
                 isFetchingMore={isFetchingMore}
                 queryPath={queryPath}
+                scrollRestorationKey={resultsScopeKey ? `${resultsScopeKey}:table` : undefined}
                 rows={rows}
                 selectedDocumentPath={selectedDocumentPath}
                 settings={settings}
@@ -285,6 +288,7 @@ export function ResultPanel(
                   <ResultTreeView
                     density={density}
                     queryPath={queryPath}
+                    scrollRestorationKey={resultsScopeKey ? `${resultsScopeKey}:tree` : undefined}
                     expandedIds={expandedTreeIds}
                     hasMore={showPagination}
                     isFetchingMore={isFetchingMore}
@@ -317,6 +321,7 @@ export function ResultPanel(
                 active={resultView === 'json'}
                 ariaLabel='JSON results'
                 mode='textarea'
+                scrollRestorationKey={resultsScopeKey ? `${resultsScopeKey}:json` : undefined}
                 value={jsonValue}
               />
             </TabsContent>

--- a/packages/product-ui/src/features/firestore/ResultTable.tsx
+++ b/packages/product-ui/src/features/firestore/ResultTable.tsx
@@ -25,6 +25,7 @@ export interface ResultTableProps {
   readonly onSettingsError?: ((message: string) => void) | undefined;
   readonly onSetFieldNull?: ((target: FieldEditTarget) => void) | undefined;
   readonly queryPath: string;
+  readonly scrollRestorationKey?: string | undefined;
   readonly rows: ReadonlyArray<FirestoreDocumentResult>;
   readonly selectedDocumentPath: string | null;
   readonly settings?: SettingsRepository | undefined;
@@ -52,6 +53,7 @@ export function ResultTable(
     onSettingsError,
     onSetFieldNull,
     queryPath,
+    scrollRestorationKey,
     rows,
     selectedDocumentPath,
     settings,
@@ -171,6 +173,7 @@ export function ResultTable(
         enableColumnResize
         getRowId={(row) => row.document.path}
         onColumnLayoutChange={saveLayout}
+        scrollRestorationKey={scrollRestorationKey}
         cellContextMenu={(row, columnId) =>
           renderCellContextMenu({
             columnId,

--- a/packages/product-ui/src/features/firestore/ResultTreeView.tsx
+++ b/packages/product-ui/src/features/firestore/ResultTreeView.tsx
@@ -32,6 +32,7 @@ export function ResultTreeView(
     onShowMoreValueChildren,
     onToggleNode,
     queryPath,
+    scrollRestorationKey,
     rows,
     subcollectionStates,
     valueChildLimits,
@@ -51,6 +52,7 @@ export function ResultTreeView(
     readonly onShowMoreValueChildren?: ((id: string) => void) | undefined;
     readonly onToggleNode: (id: string) => void;
     readonly queryPath: string;
+    readonly scrollRestorationKey?: string | undefined;
     readonly rows: ReadonlyArray<FirestoreDocumentResult>;
     readonly subcollectionStates: Readonly<Record<string, SubcollectionLoadState>>;
     readonly valueChildLimits?: ReadonlyMap<string, number> | undefined;
@@ -99,6 +101,7 @@ export function ResultTreeView(
       className='select-text'
       density={density}
       rows={treeRows}
+      scrollRestorationKey={scrollRestorationKey}
       onOpen={openNode}
       onSelect={selectNode}
       onToggle={onToggleNode}

--- a/packages/product-ui/src/features/js-query/JsonPreview.test.tsx
+++ b/packages/product-ui/src/features/js-query/JsonPreview.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { JsonPreview } from './JsonPreview.tsx';
 
@@ -25,4 +25,31 @@ describe('JsonPreview', () => {
     expect(preview.className).toContain('h-full');
     expect(preview.className).toContain('min-h-0');
   });
+
+  it('restores scroll after lazy formatting remounts the preview', async () => {
+    const value = { ok: true, rows: Array.from({ length: 50 }, (_, index) => index) };
+    const { rerender } = render(
+      <JsonPreview scrollRestorationKey='query-json' value={value} />,
+    );
+    const preview = await renderedPre();
+    preview.scrollLeft = 7;
+    preview.scrollTop = 42;
+    fireEvent.scroll(preview);
+
+    rerender(<JsonPreview active={false} scrollRestorationKey='query-json' value={value} />);
+    rerender(<JsonPreview scrollRestorationKey='query-json' value={value} />);
+
+    const restored = await renderedPre();
+    await waitFor(() => {
+      expect(restored.scrollLeft).toBe(7);
+      expect(restored.scrollTop).toBe(42);
+    });
+  });
 });
+
+async function renderedPre(): Promise<HTMLPreElement> {
+  const text = await screen.findByText(/"ok": true/);
+  const pre = text.closest('pre');
+  if (!(pre instanceof HTMLPreElement)) throw new Error('JSON preview pre missing');
+  return pre;
+}

--- a/packages/product-ui/src/jobs/JobsDrawer.test.tsx
+++ b/packages/product-ui/src/jobs/JobsDrawer.test.tsx
@@ -49,6 +49,26 @@ describe('JobsDrawer', () => {
     expect(drawer.className).toContain('h-[70vh]');
   });
 
+  it('closes on Escape from inside the drawer', () => {
+    const onClose = vi.fn();
+    render(
+      <JobsDrawer
+        jobs={[job]}
+        open
+        onCancel={vi.fn()}
+        onClearCompleted={vi.fn()}
+        onClose={onClose}
+        onExpandedChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Clear completed' }), {
+      key: 'Escape',
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it('does not double-count skipped or failed rows in progress', () => {
     render(
       <JobsDrawer

--- a/packages/product-ui/src/jobs/JobsDrawer.tsx
+++ b/packages/product-ui/src/jobs/JobsDrawer.tsx
@@ -33,6 +33,10 @@ export function JobsDrawer(
         'z-popover grid min-h-0 grid-rows-[auto_minmax(0,1fr)]',
         expanded ? 'h-[70vh] max-h-[720px]' : 'h-80',
       )}
+      tabIndex={-1}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') onClose();
+      }}
     >
       <header className='flex h-10 items-center gap-2 border-b border-border-subtle px-3'>
         <div className='min-w-0 flex-1 text-sm font-semibold text-text-primary'>Jobs</div>

--- a/packages/product-ui/src/json-preview/JsonPreview.tsx
+++ b/packages/product-ui/src/json-preview/JsonPreview.tsx
@@ -21,8 +21,8 @@ export function JsonPreview(
   const [text, setText] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const preRef = useRef<HTMLPreElement>(null);
-  const onTextareaScroll = useScrollRestoration(scrollRestorationKey, textareaRef);
-  const onPreScroll = useScrollRestoration(scrollRestorationKey, preRef);
+  const onTextareaScroll = useScrollRestoration(scrollRestorationKey, textareaRef, text);
+  const onPreScroll = useScrollRestoration(scrollRestorationKey, preRef, text);
 
   useEffect(() => {
     if (!active) {

--- a/packages/product-ui/src/json-preview/JsonPreview.tsx
+++ b/packages/product-ui/src/json-preview/JsonPreview.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@firebase-desk/ui';
-import { useEffect, useState } from 'react';
+import { cn, useScrollRestoration } from '@firebase-desk/ui';
+import { useEffect, useRef, useState } from 'react';
 
 export function JsonPreview(
   {
@@ -7,16 +7,22 @@ export function JsonPreview(
     ariaLabel,
     className,
     mode = 'pre',
+    scrollRestorationKey,
     value,
   }: {
     readonly active?: boolean;
     readonly ariaLabel?: string;
     readonly className?: string;
     readonly mode?: 'pre' | 'textarea';
+    readonly scrollRestorationKey?: string | undefined;
     readonly value: unknown;
   },
 ) {
   const [text, setText] = useState<string | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const preRef = useRef<HTMLPreElement>(null);
+  const onTextareaScroll = useScrollRestoration(scrollRestorationKey, textareaRef);
+  const onPreScroll = useScrollRestoration(scrollRestorationKey, preRef);
 
   useEffect(() => {
     if (!active) {
@@ -47,6 +53,7 @@ export function JsonPreview(
   if (mode === 'textarea') {
     return (
       <textarea
+        ref={textareaRef}
         aria-label={ariaLabel ?? 'JSON preview'}
         className={cn(
           'block h-full min-h-0 w-full resize-none border-0 bg-bg-panel p-3 font-mono text-xs text-text-secondary outline-none',
@@ -54,16 +61,19 @@ export function JsonPreview(
         )}
         readOnly
         value={text}
+        onScroll={onTextareaScroll}
       />
     );
   }
 
   return (
     <pre
+      ref={preRef}
       className={cn(
         'h-full min-h-0 select-text overflow-auto rounded-md border border-border-subtle bg-bg-subtle p-3 font-mono text-xs leading-relaxed text-text-secondary',
         className,
       )}
+      onScroll={onPreScroll}
     >
       {text}
     </pre>

--- a/packages/ui/src/VirtualList.test.tsx
+++ b/packages/ui/src/VirtualList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('@tanstack/react-virtual', () => ({
@@ -77,5 +77,35 @@ describe('VirtualList', () => {
       />,
     );
     expect(screen.queryAllByTestId('row')).toHaveLength(0);
+  });
+
+  it('restores saved scroll for the same key', () => {
+    const { container, unmount } = render(
+      <VirtualList
+        className='scroll-list'
+        items={['x', 'y']}
+        estimateSize={() => 20}
+        scrollRestorationKey='users:list'
+        renderItem={(item) => <span>{item}</span>}
+      />,
+    );
+    const list = container.querySelector<HTMLElement>('.scroll-list')!;
+    fireEvent.scroll(list, { target: { scrollLeft: 9, scrollTop: 42 } });
+
+    unmount();
+
+    const next = render(
+      <VirtualList
+        className='scroll-list'
+        items={['x', 'y']}
+        estimateSize={() => 20}
+        scrollRestorationKey='users:list'
+        renderItem={(item) => <span>{item}</span>}
+      />,
+    );
+
+    const restored = next.container.querySelector<HTMLElement>('.scroll-list')!;
+    expect(restored.scrollLeft).toBe(9);
+    expect(restored.scrollTop).toBe(42);
   });
 });

--- a/packages/ui/src/VirtualList.tsx
+++ b/packages/ui/src/VirtualList.tsx
@@ -1,7 +1,8 @@
 import { density as densityTokens, type DensityName } from '@firebase-desk/design-tokens';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { type Key, type ReactNode, useRef } from 'react';
+import { type Key, type ReactNode, useLayoutEffect, useRef } from 'react';
 import { cn } from './cn.ts';
+import { useScrollRestoration } from './scroll-restoration.ts';
 import { visibleVirtualRows } from './virtualRows.ts';
 
 export interface VirtualListProps<T> {
@@ -13,6 +14,8 @@ export interface VirtualListProps<T> {
   readonly itemClassName?: string | ((item: T, index: number) => string | undefined);
   readonly overscan?: number;
   readonly renderItem: (item: T, index: number) => ReactNode;
+  readonly scrollRestorationKey?: string | undefined;
+  readonly scrollToIndex?: number | null | undefined;
 }
 
 export function VirtualList<T>(
@@ -25,9 +28,12 @@ export function VirtualList<T>(
     items,
     overscan = 8,
     renderItem,
+    scrollRestorationKey,
+    scrollToIndex,
   }: VirtualListProps<T>,
 ) {
   const parentRef = useRef<HTMLDivElement>(null);
+  const lastScrollToIndexRef = useRef<number | null>(null);
   const rowHeight = densityTokens[density].rowHeight;
   const estimateRowSize = estimateSize ?? (() => rowHeight);
   const virtualizer = useVirtualizer({
@@ -40,6 +46,20 @@ export function VirtualList<T>(
     },
     overscan,
   });
+  const onScroll = useScrollRestoration(scrollRestorationKey, parentRef);
+  useLayoutEffect(() => {
+    if (scrollToIndex === null || scrollToIndex === undefined) return;
+    if (lastScrollToIndexRef.current === scrollToIndex) return;
+    lastScrollToIndexRef.current = scrollToIndex;
+    (
+      virtualizer as {
+        readonly scrollToIndex?: (
+          index: number,
+          options?: { readonly align?: 'auto' | 'center' | 'end' | 'start'; },
+        ) => void;
+      }
+    ).scrollToIndex?.(scrollToIndex, { align: 'auto' });
+  }, [scrollToIndex, virtualizer]);
   const virtualRows = visibleVirtualRows(
     virtualizer.getVirtualItems(),
     items.length,
@@ -47,7 +67,7 @@ export function VirtualList<T>(
   );
 
   return (
-    <div ref={parentRef} className={cn('h-full overflow-auto', className)}>
+    <div ref={parentRef} className={cn('h-full overflow-auto', className)} onScroll={onScroll}>
       <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
         {virtualRows.map((row) => {
           const item = items[row.index];

--- a/packages/ui/src/VirtualTable.tsx
+++ b/packages/ui/src/VirtualTable.tsx
@@ -6,10 +6,13 @@ import {
   type KeyboardEvent,
   type MouseEvent,
   type ReactNode,
+  useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from 'react';
 import { cn } from './cn.ts';
+import { useScrollRestoration } from './scroll-restoration.ts';
 import { visibleVirtualRows } from './virtualRows.ts';
 
 export interface VirtualTableColumn<T> {
@@ -45,6 +48,7 @@ export interface VirtualTableProps<T> {
   readonly rowHeight?: number;
   readonly rowClassName?: string | ((row: T) => string | undefined);
   readonly rowWrapper?: (rowElement: ReactNode, row: T, index: number) => ReactNode;
+  readonly scrollRestorationKey?: string | undefined;
 }
 
 export function VirtualTable<T>(
@@ -67,11 +71,14 @@ export function VirtualTable<T>(
     rowHeight,
     rows,
     rowWrapper,
+    scrollRestorationKey,
   }: VirtualTableProps<T>,
 ) {
   const parentRef = useRef<HTMLDivElement>(null);
   const lastPrimaryClickKeyRef = useRef<Key | null>(null);
+  const pendingKeyboardFocusIndexRef = useRef<number | null>(null);
   const [isResizingColumn, setIsResizingColumn] = useState(false);
+  const [focusedRowIndex, setFocusedRowIndex] = useState(0);
   const resolvedRowHeight = rowHeight ?? densityTokens[density].rowHeight;
   const tableWidth = tableContentWidth(columns);
   const tableWidthStyle = tableWidth === undefined
@@ -87,11 +94,39 @@ export function VirtualTable<T>(
     },
     overscan: 12,
   });
+  const onScroll = useScrollRestoration(scrollRestorationKey, parentRef);
   const virtualRows = visibleVirtualRows(
     virtualizer.getVirtualItems(),
     rows.length,
     resolvedRowHeight,
   );
+  const clampedFocusedRowIndex = clampRowIndex(focusedRowIndex, rows.length);
+
+  useEffect(() => {
+    setFocusedRowIndex((current) => clampRowIndex(current, rows.length));
+  }, [rows.length]);
+
+  useLayoutEffect(() => {
+    const rowIndex = pendingKeyboardFocusIndexRef.current;
+    if (rowIndex === null) return;
+    const focused = focusRow(parentRef.current, rowIndex);
+    if (focused) pendingKeyboardFocusIndexRef.current = null;
+  }, [clampedFocusedRowIndex, virtualRows]);
+
+  function moveKeyboardFocus(rowIndex: number): void {
+    const nextIndex = clampRowIndex(rowIndex, rows.length);
+    pendingKeyboardFocusIndexRef.current = nextIndex;
+    setFocusedRowIndex(nextIndex);
+    (
+      virtualizer as {
+        readonly scrollToIndex?: (
+          index: number,
+          options?: { readonly align?: 'auto' | 'center' | 'end' | 'start'; },
+        ) => void;
+      }
+    ).scrollToIndex?.(nextIndex, { align: 'auto' });
+    if (focusRow(parentRef.current, nextIndex)) pendingKeyboardFocusIndexRef.current = null;
+  }
 
   return (
     <div
@@ -100,6 +135,7 @@ export function VirtualTable<T>(
       aria-rowcount={rows.length + 1}
       className={cn('h-full overflow-auto', className)}
       role='grid'
+      onScroll={onScroll}
     >
       <div
         aria-rowindex={1}
@@ -176,6 +212,7 @@ export function VirtualTable<T>(
               aria-selected={isRowSelected?.(item, row.index) ?? undefined}
               className={cn(
                 'flex border-b border-border-subtle text-sm text-text-primary hover:bg-action-ghost-hover',
+                'focus-visible:outline-none focus-visible:shadow-[inset_0_0_0_2px_var(--color-border-focus)]',
                 onRowClick && 'cursor-pointer',
                 typeof rowClassName === 'function' ? rowClassName(item) : rowClassName,
               )}
@@ -190,9 +227,11 @@ export function VirtualTable<T>(
                 display: 'flex',
                 height: resolvedRowHeight,
               }}
-              tabIndex={onRowClick ? 0 : undefined}
+              tabIndex={onRowClick && clampedFocusedRowIndex === row.index ? 0 : -1}
+              onFocus={() => setFocusedRowIndex(row.index)}
               onClick={(event) => {
                 if (event.detail > 1) return;
+                setFocusedRowIndex(row.index);
                 lastPrimaryClickKeyRef.current = rowKey;
                 onRowClick?.(item);
               }}
@@ -214,6 +253,7 @@ export function VirtualTable<T>(
                   row: item,
                   rowIndex: row.index,
                   rowCount: rows.length,
+                  moveFocus: moveKeyboardFocus,
                 });
               }}
             >
@@ -251,6 +291,7 @@ function handleRowKeyDown<T>(
     row,
     rowCount,
     rowIndex,
+    moveFocus,
   }: {
     readonly event: KeyboardEvent<HTMLDivElement>;
     readonly onRowClick?: ((row: T) => void) | undefined;
@@ -258,6 +299,7 @@ function handleRowKeyDown<T>(
     readonly row: T;
     readonly rowCount: number;
     readonly rowIndex: number;
+    readonly moveFocus: (rowIndex: number) => void;
   },
 ): void {
   if ((event.key === 'Enter' || event.key === ' ') && onRowClick) {
@@ -269,7 +311,7 @@ function handleRowKeyDown<T>(
   const nextIndex = nextKeyboardRowIndex(event.key, rowIndex, rowCount);
   if (nextIndex === null) return;
   event.preventDefault();
-  focusRow(parent, nextIndex);
+  if (!focusRow(parent, nextIndex)) moveFocus(nextIndex);
 }
 
 function nextKeyboardRowIndex(key: string, rowIndex: number, rowCount: number): number | null {
@@ -280,10 +322,17 @@ function nextKeyboardRowIndex(key: string, rowIndex: number, rowCount: number): 
   return null;
 }
 
-function focusRow(parent: HTMLElement | null, rowIndex: number): void {
+function focusRow(parent: HTMLElement | null, rowIndex: number): boolean {
   const selector = `[data-virtual-table-row-index="${String(rowIndex)}"]`;
   const row = parent?.querySelector<HTMLElement>(selector);
-  row?.focus();
+  if (!row) return false;
+  row.focus();
+  return true;
+}
+
+function clampRowIndex(index: number, rowCount: number): number {
+  if (rowCount <= 0) return 0;
+  return Math.max(0, Math.min(index, rowCount - 1));
 }
 
 function ColumnResizeHandle<T>(

--- a/packages/ui/src/VirtualTree.tsx
+++ b/packages/ui/src/VirtualTree.tsx
@@ -5,9 +5,11 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from 'react';
+import { useScrollRestoration } from './scroll-restoration.ts';
 import { visibleVirtualRows } from './virtualRows.ts';
 
 export interface VirtualTreeNode {
@@ -27,6 +29,7 @@ export interface VirtualTreeProps {
   readonly onSelect?: (id: string) => void;
   readonly renderNode?: (node: VirtualTreeNode) => ReactNode;
   readonly ariaLabel?: string;
+  readonly scrollRestorationKey?: string | undefined;
 }
 
 export function VirtualTree(
@@ -39,11 +42,13 @@ export function VirtualTree(
     onToggle,
     renderNode,
     rowHeight,
+    scrollRestorationKey,
   }: VirtualTreeProps,
 ) {
   const [focusedIndex, setFocusedIndex] = useState(0);
   const parentRef = useRef<HTMLDivElement>(null);
   const shouldFocusRef = useRef(false);
+  const pendingKeyboardFocusIndexRef = useRef<number | null>(null);
   const resolvedRowHeight = rowHeight ?? densityTokens[density].treeRowHeight;
   const virtualizer = useVirtualizer({
     count: flattenedNodes.length,
@@ -55,6 +60,7 @@ export function VirtualTree(
     },
     overscan: 8,
   });
+  const onScroll = useScrollRestoration(scrollRestorationKey, parentRef);
   const virtualRows = visibleVirtualRows(
     virtualizer.getVirtualItems(),
     flattenedNodes.length,
@@ -69,11 +75,23 @@ export function VirtualTree(
     (index: number) => {
       const next = clampIndex(index, flattenedNodes.length);
       shouldFocusRef.current = true;
+      pendingKeyboardFocusIndexRef.current = next;
       setFocusedIndex(next);
       virtualizer.scrollToIndex(next, { align: 'auto' });
     },
     [flattenedNodes.length, virtualizer],
   );
+
+  useLayoutEffect(() => {
+    const index = pendingKeyboardFocusIndexRef.current;
+    if (index === null) return;
+    const row = parentRef.current?.querySelector<HTMLElement>(
+      `[data-virtual-tree-row-index="${String(index)}"]`,
+    );
+    if (!row) return;
+    row.focus();
+    pendingKeyboardFocusIndexRef.current = null;
+  }, [focusedIndex, virtualRows]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>, index: number, node: VirtualTreeNode) => {
@@ -100,7 +118,13 @@ export function VirtualTree(
   );
 
   return (
-    <div ref={parentRef} className='h-full overflow-auto' role='tree' aria-label={ariaLabel}>
+    <div
+      ref={parentRef}
+      className='h-full overflow-auto'
+      role='tree'
+      aria-label={ariaLabel}
+      onScroll={onScroll}
+    >
       <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
         {virtualRows.map((row) => {
           const node = flattenedNodes[row.index];
@@ -112,6 +136,7 @@ export function VirtualTree(
               aria-expanded={node.hasChildren ? node.expanded : undefined}
               aria-level={node.depth + 1}
               tabIndex={row.index === focusedIndex ? 0 : -1}
+              data-virtual-tree-row-index={row.index}
               ref={(el) => {
                 if (el && row.index === focusedIndex && el.ownerDocument.activeElement !== el) {
                   if (

--- a/packages/ui/src/data-table/DataTable.tsx
+++ b/packages/ui/src/data-table/DataTable.tsx
@@ -40,6 +40,7 @@ export interface DataTableProps<TData> {
   readonly rowContextMenu?: (row: TData) => ReactNode | null;
   readonly rowClassName?: string | ((row: TData) => string | undefined);
   readonly rowHeight?: number;
+  readonly scrollRestorationKey?: string | undefined;
   readonly selectedRowId?: string | null;
 }
 
@@ -60,6 +61,7 @@ export function DataTable<TData>(
     rowContextMenu,
     rowClassName,
     rowHeight,
+    scrollRestorationKey,
     selectedRowId,
   }: DataTableProps<TData>,
 ) {
@@ -128,6 +130,7 @@ export function DataTable<TData>(
           typeof rowClassName === 'function' ? rowClassName(row.original) : rowClassName,
         )}
       {...(rowHeight === undefined ? {} : { rowHeight })}
+      scrollRestorationKey={scrollRestorationKey}
       rows={rows}
       {...(cellContextMenu
         ? {

--- a/packages/ui/src/explorer-tree/ExplorerTree.tsx
+++ b/packages/ui/src/explorer-tree/ExplorerTree.tsx
@@ -33,6 +33,7 @@ export interface ExplorerTreeProps<TNode extends ExplorerTreeRowModel = Explorer
   readonly onToggle: (id: string) => void;
   readonly renderAction?: ((node: TNode) => ReactNode) | undefined;
   readonly rows: ReadonlyArray<TNode>;
+  readonly scrollRestorationKey?: string | undefined;
 }
 
 export function ExplorerTree<TNode extends ExplorerTreeRowModel = ExplorerTreeRowModel>(
@@ -46,9 +47,11 @@ export function ExplorerTree<TNode extends ExplorerTreeRowModel = ExplorerTreeRo
     onToggle,
     renderAction,
     rows,
+    scrollRestorationKey,
   }: ExplorerTreeProps<TNode>,
 ) {
   const [focusedIndex, setFocusedIndex] = useState(0);
+  const [scrollToIndex, setScrollToIndex] = useState<number | null>(null);
   const clampedFocusedIndex = rows.length === 0 ? 0 : Math.min(focusedIndex, rows.length - 1);
   const resolvedDensity = density ?? 'compact';
   const rowHeight = densityTokens[resolvedDensity].treeRowHeight;
@@ -61,16 +64,35 @@ export function ExplorerTree<TNode extends ExplorerTreeRowModel = ExplorerTreeRo
     });
   }, [rows.length]);
 
+  const moveFocus = useCallback(
+    (index: number) => {
+      const next = rows.length === 0 ? 0 : Math.min(Math.max(index, 0), rows.length - 1);
+      setFocusedIndex(next);
+      setScrollToIndex(next);
+    },
+    [rows.length],
+  );
+
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>, index: number, node: TNode) => {
       if (event.key === 'ArrowDown') {
         event.preventDefault();
-        setFocusedIndex(Math.min(index + 1, rows.length - 1));
+        moveFocus(index + 1);
         return;
       }
       if (event.key === 'ArrowUp') {
         event.preventDefault();
-        setFocusedIndex(Math.max(index - 1, 0));
+        moveFocus(index - 1);
+        return;
+      }
+      if (event.key === 'Home') {
+        event.preventDefault();
+        moveFocus(0);
+        return;
+      }
+      if (event.key === 'End') {
+        event.preventDefault();
+        moveFocus(rows.length - 1);
         return;
       }
       if (event.key === 'ArrowRight' && node.hasChildren && !node.expanded) {
@@ -92,7 +114,7 @@ export function ExplorerTree<TNode extends ExplorerTreeRowModel = ExplorerTreeRo
         else onOpen?.(node.id);
       }
     },
-    [onOpen, onSelect, onToggle, rows.length],
+    [moveFocus, onOpen, onSelect, onToggle, rows.length],
   );
   return (
     <div className={cn('h-full min-w-[680px] font-mono text-xs', className)} role='tree'>
@@ -116,6 +138,8 @@ export function ExplorerTree<TNode extends ExplorerTreeRowModel = ExplorerTreeRo
         )}
         density={resolvedDensity}
         estimateSize={estimateRowSize}
+        scrollRestorationKey={scrollRestorationKey}
+        scrollToIndex={scrollToIndex}
       />
     </div>
   );

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -15,6 +15,7 @@ export * from './inspector/index.ts';
 export * from './JsonTreeView.tsx';
 export * from './panel/index.ts';
 export * from './resizable-panel-group/index.ts';
+export * from './scroll-restoration.ts';
 export * from './status-badge/index.ts';
 export * from './tabs/index.ts';
 export * from './toolbar/index.ts';

--- a/packages/ui/src/scroll-restoration.ts
+++ b/packages/ui/src/scroll-restoration.ts
@@ -10,6 +10,7 @@ const scrollPositions = new Map<string, ScrollPosition>();
 export function useScrollRestoration<TElement extends HTMLElement>(
   key: string | null | undefined,
   ref: RefObject<TElement | null>,
+  restoreSignal?: unknown,
 ): (event: UIEvent<TElement>) => void {
   useLayoutEffect(() => {
     if (!key) return;
@@ -19,7 +20,7 @@ export function useScrollRestoration<TElement extends HTMLElement>(
     if (!position) return;
     element.scrollLeft = position.left;
     element.scrollTop = position.top;
-  }, [key, ref]);
+  }, [key, ref, restoreSignal]);
 
   return useCallback(
     (event: UIEvent<TElement>) => {

--- a/packages/ui/src/scroll-restoration.ts
+++ b/packages/ui/src/scroll-restoration.ts
@@ -1,0 +1,34 @@
+import { type RefObject, type UIEvent, useCallback, useLayoutEffect } from 'react';
+
+interface ScrollPosition {
+  readonly left: number;
+  readonly top: number;
+}
+
+const scrollPositions = new Map<string, ScrollPosition>();
+
+export function useScrollRestoration<TElement extends HTMLElement>(
+  key: string | null | undefined,
+  ref: RefObject<TElement | null>,
+): (event: UIEvent<TElement>) => void {
+  useLayoutEffect(() => {
+    if (!key) return;
+    const element = ref.current;
+    if (!element) return;
+    const position = scrollPositions.get(key);
+    if (!position) return;
+    element.scrollLeft = position.left;
+    element.scrollTop = position.top;
+  }, [key, ref]);
+
+  return useCallback(
+    (event: UIEvent<TElement>) => {
+      if (!key) return;
+      scrollPositions.set(key, {
+        left: event.currentTarget.scrollLeft,
+        top: event.currentTarget.scrollTop,
+      });
+    },
+    [key],
+  );
+}


### PR DESCRIPTION
## What
- Preserve result/table/tree/json scroll by tab and improve virtual table/tree keyboard focus.
- Close Activity/Jobs drawers with Escape from focused children.
- Surface native picker failures and keep collection job paths picker-driven.
- Set Windows app identity for native taskbar/notification behavior.
- Bump version to 0.0.5.

## Issues
Addresses #29
Closes #36
Closes #37
Closes #38
Closes #39
Closes #40
Closes #41

## Checks
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build