### PR TITLE
[codex] Add generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+changelog:
+    exclude:
+        labels:
+            - duplicate
+            - invalid
+            - question
+            - wontfix
+            - type:tracker
+    categories:
+        - title: Features
+          labels:
+              - enhancement
+        - title: Fixes
+          labels:
+              - bug
+        - title: Release
+          labels:
+              - area:release
+        - title: Docs
+          labels:
+              - documentation
+        - title: Dependencies
+          labels:
+              - dependencies
+        - title: Other
+          labels:
+              - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,21 @@ jobs:
                   node-version: 24
                   cache: pnpm
             - run: pnpm install --frozen-lockfile
+            - name: Validate release notes
+              run: |
+                  cat > generated-release-notes.md <<'NOTES'
+                  ## What's Changed
+
+                  * Validate release notes in CI
+                  NOTES
+                  GENERATED_RELEASE_NOTES_FILE=generated-release-notes.md \
+                    RELEASE_COMMIT="$GITHUB_SHA" \
+                    RELEASE_NOTES_FILE=/tmp/stable-release-notes.md \
+                    pnpm release:notes
+                  RELEASE_NOTES_MODE=latest \
+                    RELEASE_COMMIT="$GITHUB_SHA" \
+                    RELEASE_NOTES_FILE=/tmp/latest-release-notes.md \
+                    pnpm release:notes
             - run: pnpm format:check
             - run: pnpm lint
             - run: pnpm typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
                     RELEASE_COMMIT="$GITHUB_SHA" \
                     RELEASE_NOTES_FILE=/tmp/latest-release-notes.md \
                     pnpm release:notes
+                  grep -F "Unsigned Firebase Desk build." /tmp/stable-release-notes.md
+                  grep -F "Source commit: \`$GITHUB_SHA\`" /tmp/stable-release-notes.md
+                  grep -F "## What's Changed" /tmp/stable-release-notes.md
+                  grep -F "* Validate release notes in CI" /tmp/stable-release-notes.md
+                  grep -F "Rolling unsigned build mirrored" /tmp/latest-release-notes.md
+                  grep -F "Source commit: \`$GITHUB_SHA\`" /tmp/latest-release-notes.md
             - run: pnpm format:check
             - run: pnpm lint
             - run: pnpm typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ jobs:
             - run: pnpm install --frozen-lockfile
             - name: Validate release notes
               run: |
-                  cat > generated-release-notes.md <<'NOTES'
+                  cat > /tmp/generated-release-notes.md <<'NOTES'
                   ## What's Changed
 
                   * Validate release notes in CI
                   NOTES
-                  GENERATED_RELEASE_NOTES_FILE=generated-release-notes.md \
+                  GENERATED_RELEASE_NOTES_FILE=/tmp/generated-release-notes.md \
                     RELEASE_COMMIT="$GITHUB_SHA" \
                     RELEASE_NOTES_FILE=/tmp/stable-release-notes.md \
                     pnpm release:notes
@@ -44,6 +44,18 @@ jobs:
                   grep -F "* Validate release notes in CI" /tmp/stable-release-notes.md
                   grep -F "Rolling unsigned build mirrored" /tmp/latest-release-notes.md
                   grep -F "Source commit: \`$GITHUB_SHA\`" /tmp/latest-release-notes.md
+                  if RELEASE_NOTES_MODE=unknown \
+                    RELEASE_NOTES_FILE=/tmp/invalid-mode-notes.md \
+                    pnpm release:notes; then
+                    echo "::error::Invalid RELEASE_NOTES_MODE was accepted."
+                    exit 1
+                  fi
+                  if GENERATED_RELEASE_NOTES_FILE=/tmp/missing-generated-release-notes.md \
+                    RELEASE_NOTES_FILE=/tmp/missing-generated-notes.md \
+                    pnpm release:notes; then
+                    echo "::error::Missing generated release notes file was accepted."
+                    exit 1
+                  fi
             - run: pnpm format:check
             - run: pnpm lint
             - run: pnpm typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
                       ];
                       const packagePaths = new Set([
                           '.dockerignore',
+                          '.github/release.yml',
                           '.github/workflows/ci.yml',
                           '.github/workflows/release.yml',
                           '.github/workflows/release-gate.yml',
@@ -55,6 +56,7 @@ jobs:
                           'scripts/write-package-manager-manifests.ts',
                           'scripts/write-package-checksums.mjs',
                           'scripts/write-release-manifest.ts',
+                          'scripts/write-release-notes.ts',
                       ]);
 
                       const eventName = context.eventName;
@@ -252,13 +254,7 @@ jobs:
                   GH_TOKEN: ${{ github.token }}
                   ROLLING_RELEASE_TAG: latest
               run: |
-                  cat > release-notes.md <<'NOTES'
-                  Rolling unsigned build mirrored from the latest versioned `main` release.
-
-                  These binaries are published intentionally for development smoke testing. They are unsigned, so OS warning prompts are expected. Verify downloads with the matching SHA256SUMS asset.
-                  NOTES
-                  echo "" >> release-notes.md
-                  echo "Source commit: \`$GITHUB_SHA\`" >> release-notes.md
+                  RELEASE_NOTES_MODE=latest pnpm release:notes
 
                   if gh release view "$ROLLING_RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
                     # Update the release target to the current commit (note: the git tag itself will not move)
@@ -352,16 +348,26 @@ jobs:
                       -f sha="$expected_sha" >/dev/null
                     echo "Created tag $VERSION_TAG at $expected_sha."
                   fi
+            - name: Generate GitHub release notes
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  VERSION_TAG: ${{ needs.prepare.outputs.version_tag }}
+              run: |
+                  gh api --method POST "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+                    -f tag_name="$VERSION_TAG" \
+                    -f target_commitish="$GITHUB_SHA" \
+                    -f configuration_file_path=".github/release.yml" \
+                    --jq .body > generated-release-notes.md
+            - name: Write release notes
+              run: pnpm release:notes
+              env:
+                  GENERATED_RELEASE_NOTES_FILE: generated-release-notes.md
             - name: Publish version release
               env:
                   GH_TOKEN: ${{ github.token }}
                   MARK_LATEST: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
                   VERSION_TAG: ${{ needs.prepare.outputs.version_tag }}
               run: |
-                  cat > release-notes.md <<'NOTES'
-                  Unsigned Firebase Desk build. OS warning prompts are expected. Verify downloads with the matching SHA256SUMS asset.
-                  NOTES
-
                   latest_args=()
                   if [ "$MARK_LATEST" = "true" ]; then
                     latest_args=(--latest)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
                       ];
                       const packagePaths = new Set([
                           '.dockerignore',
-                          '.github/release.yml',
                           '.github/workflows/ci.yml',
                           '.github/workflows/release.yml',
                           '.github/workflows/release-gate.yml',
@@ -56,7 +55,6 @@ jobs:
                           'scripts/write-package-manager-manifests.ts',
                           'scripts/write-package-checksums.mjs',
                           'scripts/write-release-manifest.ts',
-                          'scripts/write-release-notes.ts',
                       ]);
 
                       const eventName = context.eventName;
@@ -146,6 +144,44 @@ jobs:
 
     ci:
         uses: ./.github/workflows/ci.yml
+
+    release-notes:
+        runs-on: ubuntu-latest
+        if: github.event_name == 'pull_request'
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@v6
+            - uses: pnpm/action-setup@v5
+              with:
+                  version: 10.33.2
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: 24
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile
+            - name: Generate GitHub release notes
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  VERSION_TAG: v0.0.${{ github.run_number }}
+              run: |
+                  gh api --method POST "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+                    -f tag_name="$VERSION_TAG" \
+                    -f target_commitish="$GITHUB_SHA" \
+                    -f configuration_file_path=".github/release.yml" \
+                    --jq .body > generated-release-notes.md
+            - name: Validate stable release notes
+              run: pnpm release:notes
+              env:
+                  GENERATED_RELEASE_NOTES_FILE: generated-release-notes.md
+                  RELEASE_COMMIT: ${{ github.sha }}
+                  RELEASE_NOTES_FILE: /tmp/stable-release-notes.md
+            - name: Validate rolling release notes
+              run: pnpm release:notes
+              env:
+                  RELEASE_COMMIT: ${{ github.sha }}
+                  RELEASE_NOTES_FILE: /tmp/latest-release-notes.md
+                  RELEASE_NOTES_MODE: latest
 
     package:
         needs: [ prepare, ci ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,16 +160,13 @@ jobs:
                   node-version: 24
                   cache: pnpm
             - run: pnpm install --frozen-lockfile
-            - name: Generate GitHub release notes
-              env:
-                  GH_TOKEN: ${{ github.token }}
-                  VERSION_TAG: v0.0.${{ github.run_number }}
+            - name: Write generated release notes fixture
               run: |
-                  gh api --method POST "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
-                    -f tag_name="$VERSION_TAG" \
-                    -f target_commitish="$GITHUB_SHA" \
-                    -f configuration_file_path=".github/release.yml" \
-                    --jq .body > generated-release-notes.md
+                  cat > generated-release-notes.md <<'NOTES'
+                  ## What's Changed
+
+                  * Validate release notes in CI
+                  NOTES
             - name: Validate stable release notes
               run: pnpm release:notes
               env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,41 +145,6 @@ jobs:
     ci:
         uses: ./.github/workflows/ci.yml
 
-    release-notes:
-        runs-on: ubuntu-latest
-        if: github.event_name == 'pull_request'
-        permissions:
-            contents: read
-        steps:
-            - uses: actions/checkout@v6
-            - uses: pnpm/action-setup@v5
-              with:
-                  version: 10.33.2
-            - uses: actions/setup-node@v6
-              with:
-                  node-version: 24
-                  cache: pnpm
-            - run: pnpm install --frozen-lockfile
-            - name: Write generated release notes fixture
-              run: |
-                  cat > generated-release-notes.md <<'NOTES'
-                  ## What's Changed
-
-                  * Validate release notes in CI
-                  NOTES
-            - name: Validate stable release notes
-              run: pnpm release:notes
-              env:
-                  GENERATED_RELEASE_NOTES_FILE: generated-release-notes.md
-                  RELEASE_COMMIT: ${{ github.sha }}
-                  RELEASE_NOTES_FILE: /tmp/stable-release-notes.md
-            - name: Validate rolling release notes
-              run: pnpm release:notes
-              env:
-                  RELEASE_COMMIT: ${{ github.sha }}
-                  RELEASE_NOTES_FILE: /tmp/latest-release-notes.md
-                  RELEASE_NOTES_MODE: latest
-
     package:
         needs: [ prepare, ci ]
         if: needs.prepare.outputs.should_package == 'true'

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebase-desk/desktop",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "license": "MIT",
   "description": "Firebase Desk Electron application.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-desk",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "description": "Firebase Desk monorepo root.",
   "license": "MIT",
@@ -35,6 +35,7 @@
     "test:smoke": "pnpm --dir e2e test:withEmulators",
     "package": "pnpm --filter @firebase-desk/desktop package",
     "release:manifest": "tsx scripts/write-release-manifest.ts",
+    "release:notes": "tsx scripts/write-release-notes.ts",
     "package-managers:manifests": "tsx scripts/write-package-manager-manifests.ts"
   },
   "devDependencies": {

--- a/scripts/write-release-notes.ts
+++ b/scripts/write-release-notes.ts
@@ -11,7 +11,7 @@ async function main(): Promise<void> {
     repositoryRoot,
     process.env['RELEASE_NOTES_FILE'] ?? 'release-notes.md',
   );
-  const mode = process.env['RELEASE_NOTES_MODE'] ?? 'stable';
+  const mode = releaseNotesMode();
   const notes = mode === 'latest' ? latestNotes() : await stableNotes();
 
   await mkdir(dirname(outputPath), { recursive: true });
@@ -46,19 +46,19 @@ Source commit: \`${releaseCommit()}\``;
 
 async function readGeneratedNotes(): Promise<string> {
   const inputPath = process.env['GENERATED_RELEASE_NOTES_FILE'];
-  if (!inputPath) return '';
-  try {
-    return (await readFile(resolve(repositoryRoot, inputPath), 'utf8')).trim();
-  } catch (error) {
-    if (isNodeError(error) && error.code === 'ENOENT') return '';
-    throw error;
+  if (inputPath === undefined) return '';
+  if (inputPath.trim().length === 0) {
+    throw new Error('GENERATED_RELEASE_NOTES_FILE must not be empty.');
   }
+  return (await readFile(resolve(repositoryRoot, inputPath), 'utf8')).trim();
+}
+
+function releaseNotesMode(): 'stable' | 'latest' {
+  const mode = process.env['RELEASE_NOTES_MODE'] ?? 'stable';
+  if (mode === 'stable' || mode === 'latest') return mode;
+  throw new Error(`Unsupported RELEASE_NOTES_MODE "${mode}". Expected "stable" or "latest".`);
 }
 
 function releaseCommit(): string {
   return process.env['RELEASE_COMMIT'] ?? process.env['GITHUB_SHA'] ?? 'local';
-}
-
-function isNodeError(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && 'code' in error;
 }

--- a/scripts/write-release-notes.ts
+++ b/scripts/write-release-notes.ts
@@ -1,0 +1,64 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+void main();
+
+async function main(): Promise<void> {
+  const outputPath = resolve(
+    repositoryRoot,
+    process.env['RELEASE_NOTES_FILE'] ?? 'release-notes.md',
+  );
+  const mode = process.env['RELEASE_NOTES_MODE'] ?? 'stable';
+  const notes = mode === 'latest' ? latestNotes() : await stableNotes();
+
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${notes.trimEnd()}\n`);
+  console.log(`Wrote ${outputPath}`);
+}
+
+async function stableNotes(): Promise<string> {
+  const generatedNotes = await readGeneratedNotes();
+  const body = generatedNotes.length > 0
+    ? generatedNotes
+    : 'No merged pull request notes were generated for this release.';
+
+  return `${stableIntro()}
+
+${body}`;
+}
+
+function stableIntro(): string {
+  return `Unsigned Firebase Desk build. OS warning prompts are expected. Verify downloads with the matching SHA256SUMS asset.
+
+Source commit: \`${releaseCommit()}\``;
+}
+
+function latestNotes(): string {
+  return `Rolling unsigned build mirrored from the latest versioned \`main\` release.
+
+These binaries are published intentionally for development smoke testing. They are unsigned, so OS warning prompts are expected. Verify downloads with the matching SHA256SUMS asset.
+
+Source commit: \`${releaseCommit()}\``;
+}
+
+async function readGeneratedNotes(): Promise<string> {
+  const inputPath = process.env['GENERATED_RELEASE_NOTES_FILE'];
+  if (!inputPath) return '';
+  try {
+    return (await readFile(resolve(repositoryRoot, inputPath), 'utf8')).trim();
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') return '';
+    throw error;
+  }
+}
+
+function releaseCommit(): string {
+  return process.env['RELEASE_COMMIT'] ?? process.env['GITHUB_SHA'] ?? 'local';
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}


### PR DESCRIPTION
## Summary
- add GitHub release note grouping config
- add `pnpm release:notes` for stable and latest notes
- wire release workflow to generate stable PR notes and keep latest smoke notes
- bump version to 0.0.8

Closes #52

## Checks
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
