### PR TITLE
fix release bump auth

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -14,6 +14,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
+                  persist-credentials: false
             - uses: actions/setup-node@v6
               with:
                   node-version: 24


### PR DESCRIPTION
Fix release-bump checkout credentials so RELEASE_BOT_TOKEN is used for branch pushes.

Checks:
- pnpm test:release-automation
- pnpm format:check