### PR TITLE
pin actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
             - name: Skip release bump CI
               if: ${{ inputs.skip_expensive || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'automation:release-bump')) }}
               run: echo "Release bump PR only changes package versions; release-policy validates it."
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
               if: ${{ !inputs.skip_expensive && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'automation:release-bump')) }}
-            - uses: pnpm/action-setup@v5
+            - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
               if: ${{ !inputs.skip_expensive && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'automation:release-bump')) }}
               with:
                   version: 10.33.2
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
               if: ${{ !inputs.skip_expensive && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'automation:release-bump')) }}
               with:
                   node-version: 24

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
             - name: Skip release bump CI
               if: ${{ inputs.skip_expensive || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'automation:release-bump')) }}
               run: echo "Release bump PR only changes package versions; release-policy validates it."
-            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               if: ${{ !inputs.skip_expensive && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'automation:release-bump')) }}
-            - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
+            - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
               if: ${{ !inputs.skip_expensive && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'automation:release-bump')) }}
               with:
                   version: 10.33.2
-            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               if: ${{ !inputs.skip_expensive && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'automation:release-bump')) }}
               with:
                   node-version: 24

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,16 +18,16 @@ jobs:
             - name: Skip release bump e2e
               if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'automation:release-bump')
               run: echo "Release bump PR only changes package versions; release-policy validates it."
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
               if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'automation:release-bump')
-            - uses: pnpm/action-setup@v5
+            - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
               if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'automation:release-bump')
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
               if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'automation:release-bump')
               with:
                   node-version: 24
                   cache: pnpm
-            - uses: actions/setup-java@v5
+            - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
               if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'automation:release-bump')
               with:
                   distribution: temurin
@@ -51,7 +51,7 @@ jobs:
                   @firebase-desk/emulator-tools seed && pnpm --filter
                   @firebase-desk/e2e test:e2e"
             - if: failure()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
               with:
                   name: playwright-report
                   if-no-files-found: ignore

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,16 +18,16 @@ jobs:
             - name: Skip release bump e2e
               if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'automation:release-bump')
               run: echo "Release bump PR only changes package versions; release-policy validates it."
-            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'automation:release-bump')
-            - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
+            - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
               if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'automation:release-bump')
-            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'automation:release-bump')
               with:
                   node-version: 24
                   cache: pnpm
-            - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+            - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
               if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'automation:release-bump')
               with:
                   distribution: temurin
@@ -51,7 +51,7 @@ jobs:
                   @firebase-desk/emulator-tools seed && pnpm --filter
                   @firebase-desk/e2e test:e2e"
             - if: failure()
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: playwright-report
                   if-no-files-found: ignore

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,9 +45,9 @@ jobs:
               run: pnpm --filter @firebase-desk/e2e exec playwright install --with-deps
                   chromium
             - if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'automation:release-bump')
-              run: xvfb-run --auto-servernum -- pnpm dlx firebase-tools@15.15.0 --project
-                  demo-local emulators:exec --only auth,firestore --config
-                  firebase/emulator/firebase.json "pnpm --filter
+              run: xvfb-run --auto-servernum -- pnpm dlx --allow-build=protobufjs
+                  --allow-build=re2 firebase-tools@15.15.0 --project demo-local emulators:exec --only
+                  auth,firestore --config firebase/emulator/firebase.json "pnpm --filter
                   @firebase-desk/emulator-tools seed && pnpm --filter
                   @firebase-desk/e2e test:e2e"
             - if: failure()

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,18 +18,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
         with:
           version: 10.33.2
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm docs:build
-      - uses: actions/configure-pages@v6
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: apps/docs/.build/site
 
@@ -41,4 +41,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,18 +18,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         with:
           version: 10.33.2
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm docs:build
-      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
-      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: apps/docs/.build/site
 
@@ -41,4 +41,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -11,11 +11,11 @@ jobs:
     release-bump:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0
                   persist-credentials: false
-            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: 24
             - name: Require release bot token

--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -11,11 +11,11 @@ jobs:
     release-bump:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
               with:
                   fetch-depth: 0
                   persist-credentials: false
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
               with:
                   node-version: 24
             - name: Require release bot token

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -13,8 +13,8 @@ jobs:
     release-policy:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions/setup-node@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
               with:
                   node-version: 24
             - name: Validate release policy

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -13,8 +13,8 @@ jobs:
     release-policy:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: 24
             - name: Validate release policy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,16 +181,16 @@ jobs:
             - name: Smoke packaged app with emulators (Linux)
               if: needs.prepare.outputs.should_package == 'true' && matrix.platform == 'linux'
               run: |
-                  xvfb-run --auto-servernum -- pnpm dlx firebase-tools@15.15.0 --project demo-local emulators:exec --only auth,firestore --config firebase/emulator/firebase.json "pnpm --filter @firebase-desk/emulator-tools seed && pnpm --filter @firebase-desk/e2e test:packaged"
+                  xvfb-run --auto-servernum -- pnpm dlx --allow-build=protobufjs --allow-build=re2 firebase-tools@15.15.0 --project demo-local emulators:exec --only auth,firestore --config firebase/emulator/firebase.json "pnpm --filter @firebase-desk/emulator-tools seed && pnpm --filter @firebase-desk/e2e test:packaged"
             - name: Smoke packaged app with emulators (macOS)
               if: needs.prepare.outputs.should_package == 'true' && matrix.platform == 'macos'
               run: |
-                  pnpm dlx firebase-tools@15.15.0 --project demo-local emulators:exec --only auth,firestore --config firebase/emulator/firebase.json "pnpm --filter @firebase-desk/emulator-tools seed && pnpm --filter @firebase-desk/e2e test:packaged"
+                  pnpm dlx --allow-build=protobufjs --allow-build=re2 firebase-tools@15.15.0 --project demo-local emulators:exec --only auth,firestore --config firebase/emulator/firebase.json "pnpm --filter @firebase-desk/emulator-tools seed && pnpm --filter @firebase-desk/e2e test:packaged"
             - name: Smoke packaged app with emulators (Windows)
               if: needs.prepare.outputs.should_package == 'true' && matrix.platform == 'windows'
               shell: bash
               run: |
-                  pnpm dlx firebase-tools@15.15.0 --project demo-local emulators:exec --only auth,firestore --config firebase/emulator/firebase.json "pnpm --filter @firebase-desk/emulator-tools seed && pnpm --filter @firebase-desk/e2e test:packaged"
+                  pnpm dlx --allow-build=protobufjs --allow-build=re2 firebase-tools@15.15.0 --project demo-local emulators:exec --only auth,firestore --config firebase/emulator/firebase.json "pnpm --filter @firebase-desk/emulator-tools seed && pnpm --filter @firebase-desk/e2e test:packaged"
             - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
               if: needs.prepare.outputs.should_package == 'true'
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
             should_package: ${{ steps.plan.outputs.should_package }}
             version_tag: ${{ steps.plan.outputs.version_tag }}
         steps:
-            - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+            - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               id: plan
               with:
                   script: |
@@ -132,18 +132,18 @@ jobs:
             - name: Skip package
               if: needs.prepare.outputs.should_package != 'true'
               run: echo "Packaging skipped because prepare set should_package=false."
-            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               if: needs.prepare.outputs.should_package == 'true'
-            - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
+            - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
               if: needs.prepare.outputs.should_package == 'true'
               with:
                   version: 10.33.2
-            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               if: needs.prepare.outputs.should_package == 'true'
               with:
                   node-version: 24
                   cache: pnpm
-            - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+            - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
               if: needs.prepare.outputs.should_package == 'true' && matrix.smoke == 'packaged'
               with:
                   distribution: temurin
@@ -191,7 +191,7 @@ jobs:
               shell: bash
               run: |
                   pnpm dlx --allow-build=protobufjs --allow-build=re2 firebase-tools@15.15.0 --project demo-local emulators:exec --only auth,firestore --config firebase/emulator/firebase.json "pnpm --filter @firebase-desk/emulator-tools seed && pnpm --filter @firebase-desk/e2e test:packaged"
-            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               if: needs.prepare.outputs.should_package == 'true'
               with:
                   name: ${{ steps.package_names.outputs.artifact }}
@@ -212,16 +212,16 @@ jobs:
         permissions:
             contents: write
         steps:
-            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-            - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
               with:
                   version: 10.33.2
-            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: 24
                   cache: pnpm
             - run: pnpm install --frozen-lockfile
-            - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+            - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   path: artifacts
             - name: Write release manifest
@@ -260,16 +260,16 @@ jobs:
         permissions:
             contents: write
         steps:
-            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-            - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
               with:
                   version: 10.33.2
-            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: 24
                   cache: pnpm
             - run: pnpm install --frozen-lockfile
-            - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+            - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   path: artifacts
             - name: Write release manifest
@@ -286,7 +286,7 @@ jobs:
                   PACKAGE_MANAGER_MANIFEST_DIR: package-manager-manifests
                   RELEASE_MANIFEST_FILE: artifacts/release-manifest.json
                   RELEASE_TAG: ${{ needs.prepare.outputs.version_tag }}
-            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: package-manager-manifests-${{ needs.prepare.outputs.version_tag }}
                   path: package-manager-manifests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
             should_package: ${{ steps.plan.outputs.should_package }}
             version_tag: ${{ steps.plan.outputs.version_tag }}
         steps:
-            - uses: actions/github-script@v8
+            - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
               id: plan
               with:
                   script: |
@@ -132,18 +132,18 @@ jobs:
             - name: Skip package
               if: needs.prepare.outputs.should_package != 'true'
               run: echo "Packaging skipped because prepare set should_package=false."
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
               if: needs.prepare.outputs.should_package == 'true'
-            - uses: pnpm/action-setup@v5
+            - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
               if: needs.prepare.outputs.should_package == 'true'
               with:
                   version: 10.33.2
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
               if: needs.prepare.outputs.should_package == 'true'
               with:
                   node-version: 24
                   cache: pnpm
-            - uses: actions/setup-java@v5
+            - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
               if: needs.prepare.outputs.should_package == 'true' && matrix.smoke == 'packaged'
               with:
                   distribution: temurin
@@ -191,7 +191,7 @@ jobs:
               shell: bash
               run: |
                   pnpm dlx firebase-tools@15.15.0 --project demo-local emulators:exec --only auth,firestore --config firebase/emulator/firebase.json "pnpm --filter @firebase-desk/emulator-tools seed && pnpm --filter @firebase-desk/e2e test:packaged"
-            - uses: actions/upload-artifact@v7
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
               if: needs.prepare.outputs.should_package == 'true'
               with:
                   name: ${{ steps.package_names.outputs.artifact }}
@@ -212,16 +212,16 @@ jobs:
         permissions:
             contents: write
         steps:
-            - uses: actions/checkout@v6
-            - uses: pnpm/action-setup@v5
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+            - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
               with:
                   version: 10.33.2
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
               with:
                   node-version: 24
                   cache: pnpm
             - run: pnpm install --frozen-lockfile
-            - uses: actions/download-artifact@v7
+            - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
               with:
                   path: artifacts
             - name: Write release manifest
@@ -260,16 +260,16 @@ jobs:
         permissions:
             contents: write
         steps:
-            - uses: actions/checkout@v6
-            - uses: pnpm/action-setup@v5
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+            - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d
               with:
                   version: 10.33.2
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
               with:
                   node-version: 24
                   cache: pnpm
             - run: pnpm install --frozen-lockfile
-            - uses: actions/download-artifact@v7
+            - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
               with:
                   path: artifacts
             - name: Write release manifest
@@ -286,7 +286,7 @@ jobs:
                   PACKAGE_MANAGER_MANIFEST_DIR: package-manager-manifests
                   RELEASE_MANIFEST_FILE: artifacts/release-manifest.json
                   RELEASE_TAG: ${{ needs.prepare.outputs.version_tag }}
-            - uses: actions/upload-artifact@v7
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
               with:
                   name: package-manager-manifests-${{ needs.prepare.outputs.version_tag }}
                   path: package-manager-manifests

--- a/scripts/package-linux-docker.sh
+++ b/scripts/package-linux-docker.sh
@@ -9,4 +9,4 @@ sudo chown root:root apps/desktop/release/linux-unpacked/chrome-sandbox
 sudo chmod 4755 apps/desktop/release/linux-unpacked/chrome-sandbox
 ls -l apps/desktop/release/linux-unpacked/chrome-sandbox
 
-xvfb-run --auto-servernum -- pnpm dlx firebase-tools@15.15.0 --project demo-local emulators:exec --only auth,firestore --config firebase/emulator/firebase.json "pnpm --filter @firebase-desk/emulator-tools seed && pnpm --filter @firebase-desk/e2e test:packaged"
+xvfb-run --auto-servernum -- pnpm dlx --allow-build=protobufjs --allow-build=re2 firebase-tools@15.15.0 --project demo-local emulators:exec --only auth,firestore --config firebase/emulator/firebase.json "pnpm --filter @firebase-desk/emulator-tools seed && pnpm --filter @firebase-desk/e2e test:packaged"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -22,4 +22,4 @@ run pnpm build
 run pnpm --filter @firebase-desk/e2e typecheck
 run pnpm --filter @firebase-desk/e2e exec playwright install chromium
 run pnpm docs:smoke
-run pnpm dlx firebase-tools@15.15.0 --project demo-local emulators:exec --only auth,firestore --config firebase/emulator/firebase.json "pnpm --filter @firebase-desk/emulator-tools seed && pnpm --filter @firebase-desk/e2e test:e2e"
+run pnpm dlx --allow-build=protobufjs --allow-build=re2 firebase-tools@15.15.0 --project demo-local emulators:exec --only auth,firestore --config firebase/emulator/firebase.json "pnpm --filter @firebase-desk/emulator-tools seed && pnpm --filter @firebase-desk/e2e test:e2e"


### PR DESCRIPTION
Pin external GitHub Actions to full-length commit SHAs and move workflow actions to current exact releases before repo SHA enforcement is enabled.

Also configured the repo Actions allowlist to only permit the action repos used by current workflows.

Checks:
- pnpm format:check
- pnpm test:release-automation
- external action SHA scan