### PR TITLE
fix release bump branch

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -65,8 +65,9 @@ jobs:
                   GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
                   TITLE: ${{ steps.plan.outputs.title }}
               run: |
-                  if gh pr view "$BRANCH" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-                    gh pr edit "$BRANCH" --repo "$GITHUB_REPOSITORY" --title "$TITLE" --body-file "$BODY_FILE" --add-label automation:release-bump
+                  pr_number="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "$BRANCH" --json number --jq '.[0].number // ""')"
+                  if [ -n "$pr_number" ]; then
+                    gh pr edit "$pr_number" --repo "$GITHUB_REPOSITORY" --title "$TITLE" --body-file "$BODY_FILE" --add-label automation:release-bump
                   else
                     gh pr create --repo "$GITHUB_REPOSITORY" --base main --head "$BRANCH" --title "$TITLE" --body-file "$BODY_FILE" --label automation:release-bump
                   fi

--- a/scripts/release-bump.mjs
+++ b/scripts/release-bump.mjs
@@ -8,7 +8,7 @@ import { pathToFileURL } from 'node:url';
 
 import { AUTOMATION_LABEL } from './release-policy.mjs';
 
-export const RELEASE_BRANCH = 'release/bump';
+export const RELEASE_BRANCH_PREFIX = 'release/bump';
 export const RELEASE_LEVELS = Object.freeze(['patch', 'minor', 'major']);
 export const RELEASE_LABEL_TO_LEVEL = Object.freeze({
   'release:patch': 'patch',
@@ -53,7 +53,7 @@ export function planReleaseBump({ currentVersion, latestTag, pullRequests }) {
 
   const nextVersion = bumpVersion(currentVersion, level);
   return {
-    branch: RELEASE_BRANCH,
+    branch: releaseBranch(nextVersion),
     includedPullRequests,
     latestTag,
     level,
@@ -85,6 +85,13 @@ export function bumpVersion(version, level) {
   if (level === 'minor') return `${major}.${minor + 1}.0`;
   if (level === 'patch') return `${major}.${minor}.${patch + 1}`;
   throw new Error(`Unsupported release level "${level}".`);
+}
+
+export function releaseBranch(version) {
+  if (!stableVersionPattern.test(version)) {
+    throw new Error(`Release branch version must be stable semver, got ${version}.`);
+  }
+  return `${RELEASE_BRANCH_PREFIX}/v${version}`;
 }
 
 async function main() {

--- a/scripts/release-bump.test.mjs
+++ b/scripts/release-bump.test.mjs
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { bumpVersion, planReleaseBump, pullRequestNumbersFromSubjects } from './release-bump.mjs';
+import {
+  bumpVersion,
+  planReleaseBump,
+  pullRequestNumbersFromSubjects,
+  releaseBranch,
+} from './release-bump.mjs';
 
 describe('bumpVersion', () => {
   it('bumps patch versions', () => {
@@ -14,6 +19,12 @@ describe('bumpVersion', () => {
 
   it('bumps major versions', () => {
     assert.equal(bumpVersion('0.0.8', 'major'), '1.0.0');
+  });
+});
+
+describe('releaseBranch', () => {
+  it('uses the target version in the release branch name', () => {
+    assert.equal(releaseBranch('0.2.0'), 'release/bump/v0.2.0');
   });
 });
 
@@ -50,6 +61,7 @@ describe('planReleaseBump', () => {
     });
 
     assert.equal(plan.shouldBump, true);
+    assert.equal(plan.branch, 'release/bump/v0.0.9');
     assert.equal(plan.nextVersion, '0.0.9');
   });
 


### PR DESCRIPTION
Fix release-bump PR creation after a previous release bump PR was merged.

Root cause: the workflow reused the fixed release/bump branch name, so gh matched the old merged PR #67 instead of creating a fresh release bump PR.

Changes:
- use versioned release bump branches like release/bump/v0.2.0
- only edit an existing open PR for the exact head branch
- cover branch naming in release automation tests

Checks:
- pnpm format:check
- pnpm test:release-automation
- bash -n scripts/pre-commit.sh scripts/package-linux-docker.sh
- external action SHA/comment scan